### PR TITLE
Fix issues with Buffer and node process

### DIFF
--- a/.changeset/ten-laws-notice.md
+++ b/.changeset/ten-laws-notice.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sdk-client-v2": patch
+---
+
+Fix issues with Buffer and node process

--- a/packages/sdk-client/src/client-builder/ClientBuilder.ts
+++ b/packages/sdk-client/src/client-builder/ClientBuilder.ts
@@ -95,8 +95,8 @@ export default class ClientBuilder {
         host: options.host || 'https://auth.europe-west1.gcp.commercetools.com',
         projectKey: options.projectKey || this.projectKey,
         credentials: {
-          clientId: process.env.myClientId,
-          clientSecret: process.env.myClientSecret,
+          clientId: options.credentials.clientId || '',
+          clientSecret: options.credentials.clientSecret || '',
           user: {
             username: options.credentials.user.username || '',
             password: options.credentials.user.password || '',

--- a/packages/sdk-client/src/http-user-agent/create-user-agent.ts
+++ b/packages/sdk-client/src/http-user-agent/create-user-agent.ts
@@ -16,7 +16,7 @@ const isBrowser = () =>
 function getSystemInfo() {
   if (isBrowser()) return window.navigator.userAgent
 
-  const nodeVersion = process.version.slice(1)
+  const nodeVersion = process?.version.slice(1) || '12' // temporary fix for rn environment
   // const platformInfo = `(${process.platform}; ${process.arch})`
   // return `Node.js/${nodeVersion} ${platformInfo}`
 

--- a/packages/sdk-client/src/sdk-middleware-auth/base-auth-flow.ts
+++ b/packages/sdk-client/src/sdk-middleware-auth/base-auth-flow.ts
@@ -10,6 +10,8 @@ import {
 } from '../types/sdk.d'
 import { buildRequestForRefreshTokenFlow } from './build-requests'
 
+const Buffer = require('buffer/').Buffer
+
 function mergeAuthHeader(
   token: string,
   req: MiddlewareRequest

--- a/packages/sdk-client/src/sdk-middleware-auth/build-requests.ts
+++ b/packages/sdk-client/src/sdk-middleware-auth/build-requests.ts
@@ -12,16 +12,14 @@ interface IBuiltRequestParams {
 
 // POST https://{host}/oauth/token?grant_type=client_credentials&scope={scope}
 // Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+const Buffer = require('buffer/').Buffer
 export function buildRequestForClientCredentialsFlow(
   options: AuthMiddlewareOptions
 ): IBuiltRequestParams {
   if (!options) throw new Error('Missing required options')
-
   if (!options.host) throw new Error('Missing required option (host)')
-
   if (!options.projectKey)
     throw new Error('Missing required option (projectKey)')
-
   if (!options.credentials)
     throw new Error('Missing required option (credentials)')
 

--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -11,6 +11,7 @@ import {
   RequestOptions,
 } from '../types/sdk.d'
 import parseHeaders from './parse-headers'
+const Buffer = require('buffer/').Buffer
 
 function createError({
   statusCode,

--- a/packages/sdk-client/test/http.test/http.test.ts
+++ b/packages/sdk-client/test/http.test/http.test.ts
@@ -4,6 +4,7 @@ import AbortController from 'abort-controller'
 import { createHttpMiddleware } from '../../src/sdk-middleware-http'
 import { MiddlewareRequest, MiddlewareResponse } from '../../src/types/sdk.d'
 
+const Buffer = require('buffer/').Buffer
 function createTestRequest(options) {
   return {
     uri: '',


### PR DESCRIPTION
## Summary

Fix the issues with node environments on different platforms by

- [x] Using cross-platform buffer object instead of node.js native buffer
- [x] Adding a fallback for `node.js` version number in environments without node.js process support