### PR TITLE
Update README.md

### DIFF
--- a/packages/importapi-sdk/README.md
+++ b/packages/importapi-sdk/README.md
@@ -54,7 +54,7 @@ const authMiddlewareOptions = {
 }
 
 const httpMiddlewareOptions = {
-  host: 'https://api.europe-west1.gcp.commercetools.com',
+  host: 'https://import.europe-west1.gcp.commercetools.com',
   fetch,
 }
 
@@ -79,9 +79,10 @@ const apiRoot = createApiBuilderFromCtpClient(client)
 // calling the importapi functions
 // get project details
 apiRoot
-  .withProjectKey({
+  .withProjectKeyValue({
     projectKey,
   })
+  .importContainers()
   .get()
   .execute()
   .then((x) => {


### PR DESCRIPTION
Three changes proposed:
1- use correct url for import API
2- withProjectKey method does not exist anymore, use withProjectKeyValue instead
3- using apiRoot with get directly does not work, use import-containers endpoint instead