### PR TITLE
Add includeRequestInErrorResponse to HttpMiddlewareOptions

### DIFF
--- a/.changeset/small-numbers-peel.md
+++ b/.changeset/small-numbers-peel.md
@@ -2,4 +2,4 @@
 '@commercetools/sdk-client-v2': patch
 ---
 
-add an option (`excludeRequestInErrorResponse`) to exclude original request from error responses.
+- add an option (`includeRequestInErrorResponse`) to include or exclude original request from error responses.

--- a/.changeset/small-numbers-peel.md
+++ b/.changeset/small-numbers-peel.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sdk-client-v2': patch
+---
+
+add an option (`excludeRequestInErrorResponse`) to exclude original request from error responses.

--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -65,6 +65,7 @@ export default function createHttpMiddleware({
   credentialsMode,
   includeResponseHeaders,
   includeOriginalRequest,
+  includeRequestInErrorResponse = true,
   maskSensitiveHeaderData = true,
   enableRetry,
   timeout,
@@ -244,7 +245,9 @@ export default function createHttpMiddleware({
 
                 const error: HttpErrorType = createError({
                   statusCode: res.status,
-                  originalRequest: request,
+                  ...(includeRequestInErrorResponse
+                    ? { originalRequest: request }
+                    : {}),
                   retryCount,
                   headers: parseHeaders(res.headers),
                   ...(typeof parsed === 'object'
@@ -302,7 +305,9 @@ export default function createHttpMiddleware({
                 }
 
               const error = new NetworkError(e.message, {
-                originalRequest: request,
+                ...(includeRequestInErrorResponse
+                  ? { originalRequest: request }
+                  : {}),
                 retryCount,
               })
               maskAuthData(error.originalRequest, maskSensitiveHeaderData)

--- a/packages/sdk-client/src/types/sdk.d.ts
+++ b/packages/sdk-client/src/types/sdk.d.ts
@@ -315,6 +315,7 @@ export type HttpMiddlewareOptions = {
   includeHeaders?: boolean
   includeResponseHeaders?: boolean
   includeOriginalRequest?: boolean
+  includeRequestInErrorResponse?: boolean
   maskSensitiveHeaderData?: boolean
   timeout?: number
   enableRetry?: boolean


### PR DESCRIPTION
### Summary
Add options to include or exclude original client request from error response

### Details
- [x] add an option - `includeRequestInErrorResponse` to httpMiddlewareOptions.
- [x] add test to validate functionality
- [x] add changeset to track changes

### Related Issues
[#240](https://github.com/commercetools/commercetools-sdk-typescript/issues/240)
