### PR TITLE
Better error message on failed http request

### DIFF
--- a/packages/sdk-client/src/sdk-middleware-auth/base-auth-flow.ts
+++ b/packages/sdk-client/src/sdk-middleware-auth/base-auth-flow.ts
@@ -92,12 +92,18 @@ async function executeRequest({
     }
 
     // Handle error response
-    let parsed
-    const text: any = await _res.text()
-    try {
-      parsed = JSON.parse(text)
-    } catch (error) {
-      /* noop */
+    let parsed: any;
+    let text: string;
+    if (!_res.ok) {
+      text = `${url}: ${_res.statusText}`;
+    } else {
+      text = await _res.text();
+
+      try {
+        parsed = JSON.parse(text);
+      } catch (error) {
+        /* noop */
+      }
     }
 
     const error: any = new Error(parsed ? parsed.message : text)


### PR DESCRIPTION
When we get a 404, the returned error is empty and not helpful. Make sure we report at least the url and the status text in that case.