### PR TITLE
Chore: Replace importSinks method with importContainers

### DIFF
--- a/packages/importapi-sdk/test/misc.test.ts
+++ b/packages/importapi-sdk/test/misc.test.ts
@@ -2,7 +2,7 @@ import { ctpApiBuilder } from './helpers/ctp-api-helper'
 
 test.skip('check can get project info', async () => {
   const res = await ctpApiBuilder
-    .importSinks()
+    .importContainers()
     .get({ queryArgs: { limit: 1, offset: 0 } })
     .execute()
   expect(res.statusCode).toEqual(200)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 
 const generalConfig = {
+  stats: 'errors-only',
   watchOptions: {
     aggregateTimeout: 600,
     ignored: /node_modules/,


### PR DESCRIPTION
### Summary

- [x] Fix issues with webpack build by replacing `importSinks` with `importContainers`
- [x] Configure webpack log level to `errors-only`