### PR TITLE
Fix incorrect list of env variables in me endpoint README.md file

### DIFF
--- a/examples/me/README.md
+++ b/examples/me/README.md
@@ -26,10 +26,12 @@ PORT=8085
 CTP_CLIENT_ID={clientID}
 CTP_PROJECT_KEY={projectKey}
 CTP_CLIENT_SECRET={clientSecret}
+CTP_AUTH_URL={authUrl}
+CTP_HOST_URL={hostUrl}
 DEFAULT_CURRENCY=EUR
 ```
 
-6. Replace `{clientID}`, `{projectKey}`, and `{clientSecret}` with the respective values from your API Client. The `DEFAULT_CURRENCY` can be changed based on your Composable Commerce Project settings.
+6. Replace `{clientID}`, `{projectKey}`, `{authUrl}`, `{hostUrl}` and `{clientSecret}` with the respective values from your API Client. The `DEFAULT_CURRENCY` can be changed based on your Composable Commerce Project settings.
 
 ## Using the ME Endpoint Checkout App
 


### PR DESCRIPTION
### Summary

- [x] Add missing `env` variables to [README.md](https://github.com/commercetools/commercetools-sdk-typescript/tree/master/examples/me) in me endpoint example directory.

### Related Issue
Fixes #285 