### PR TITLE
Fix content-type to allow application/graphql

### DIFF
--- a/.changeset/empty-otters-bow.md
+++ b/.changeset/empty-otters-bow.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sdk-client-v2": patch
+---
+
+Allow `sdk-client` to accept request headers with `application/graphql` content-type.

--- a/examples/me/README.md
+++ b/examples/me/README.md
@@ -27,7 +27,7 @@ CTP_CLIENT_ID={clientID}
 CTP_PROJECT_KEY={projectKey}
 CTP_CLIENT_SECRET={clientSecret}
 CTP_AUTH_URL={authUrl}
-CTP_HOST_URL={hostUrl}
+CTP_API_URL={hostUrl}
 DEFAULT_CURRENCY=EUR
 ```
 

--- a/examples/me/server/src/utils/options.ts
+++ b/examples/me/server/src/utils/options.ts
@@ -47,7 +47,7 @@ export function getOptions(
     projectKey: process.env.CTP_PROJECT_KEY,
     credentials: _credentials ? true : false,
     httpMiddlewareOptions: {
-      host: process.env.CTP_HOST_URL,
+      host: process.env.CTP_API_URL,
       fetch,
     },
   }

--- a/packages/sdk-client/src/client-builder/ClientBuilder.ts
+++ b/packages/sdk-client/src/client-builder/ClientBuilder.ts
@@ -199,9 +199,9 @@ export default class ClientBuilder {
       middlewares.push(this.correlationIdMiddleware)
     if (this.userAgentMiddleware) middlewares.push(this.userAgentMiddleware)
     if (this.authMiddleware) middlewares.push(this.authMiddleware)
-    if (this.loggerMiddleware) middlewares.push(this.loggerMiddleware)
     if (this.queueMiddleware) middlewares.push(this.queueMiddleware)
     if (this.httpMiddleware) middlewares.push(this.httpMiddleware)
+    if (this.loggerMiddleware) middlewares.push(this.loggerMiddleware)
 
     return createClient({ middlewares })
   }

--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -128,7 +128,9 @@ export default function createHttpMiddleware({
 
       // Ensure body is a string if content type is application/json
       const body =
-        (requestHeader['Content-Type'] === 'application/json' &&
+        (['application/json', 'application/graphql'].indexOf(
+          requestHeader['Content-Type'] as string
+        ) > -1 &&
           typeof request.body === 'string') ||
         Buffer.isBuffer(request.body)
           ? request.body


### PR DESCRIPTION
### Summary

- [x] include application/graphql as an acceptable header content-type
- [x] reorder middleware to allow logger to be able to log request and response after all actions
- [x] rename environment variable CTP_HOST_URL to CTP_API_URL for consistency

### Related Issues
- [x] [#316](https://github.com/commercetools/commercetools-sdk-typescript/issues/316)
- [x] [#306](https://github.com/commercetools/commercetools-sdk-typescript/issues/306)