### PR TITLE
fix: made options to withExistingTokenFlow optional

### DIFF
--- a/.changeset/violet-timers-sin.md
+++ b/.changeset/violet-timers-sin.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sdk-client-v2": patch
+---
+
+fix: make options for `withExistingTokenFlow` method optional

--- a/packages/sdk-client/src/client-builder/ClientBuilder.ts
+++ b/packages/sdk-client/src/client-builder/ClientBuilder.ts
@@ -145,7 +145,7 @@ export default class ClientBuilder {
 
   withExistingTokenFlow(
     authorization: string,
-    options: ExistingTokenMiddlewareOptions
+    options?: ExistingTokenMiddlewareOptions
   ): ClientBuilder {
     return this.withAuthMiddleware(
       createAuthMiddlewareWithExistingToken(authorization, {


### PR DESCRIPTION
### What does this PR do?

Changes the `withExistingTokenFlow` type so that the second argument, `options` is optional.

### Why is this PR needed?

Currently as the second argument is required but you don't need to alter the options you need to pass an empty object to appease TypeScript:

`.withExistingTokenFlow('random-token', {})` 

[Mentioned in issue 319](https://github.com/commercetools/commercetools-sdk-typescript/issues/319)

### How was this PR achieved?

By making the second argument optional:

```typescript
 withExistingTokenFlow(
    authorization: string,
    options?: ExistingTokenMiddlewareOptions
  )
```