### PR TITLE
Fix requests with image/* header content-type

### DIFF
--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -119,9 +119,12 @@ export default function createHttpMiddleware({
       if (requestHeader['Content-Type'] === null) {
         delete requestHeader['Content-Type']
       }
+
       if (
-        !Object.prototype.hasOwnProperty.call(requestHeader, 'Content-Type') ||
-        !Object.prototype.hasOwnProperty.call(requestHeader, 'content-type')
+        !(
+          Object.prototype.hasOwnProperty.call(requestHeader, 'Content-Type') ||
+          Object.prototype.hasOwnProperty.call(requestHeader, 'content-type')
+        )
       ) {
         requestHeader['Content-Type'] = 'application/json'
       }

--- a/packages/sdk-client/test/http.test/http.test.ts
+++ b/packages/sdk-client/test/http.test/http.test.ts
@@ -683,6 +683,42 @@ describe('Http', () => {
       httpMiddleware(next)(request, response)
     }))
 
+  test('should not default other header content-type to application/json', () =>
+    new Promise((resolve: (value?: unknown) => void, reject): void => {
+      const request = createTestRequest({
+        uri: '/default-header/content-type',
+        method: 'POST',
+        body: { id: 'test-id' },
+        headers: {
+          'Content-Type': 'image/jpeg',
+        },
+      })
+
+      const response = { resolve, reject, statusCode: undefined }
+      const next = (req, res) => {
+        expect(req.headers).toEqual({ 'Content-Type': 'image/jpeg' })
+        expect(res).toEqual({
+          ...response,
+          body: { id: 'test-id' },
+          statusCode: 200,
+        })
+        resolve()
+      }
+      // Use custom options
+      const httpMiddleware = createHttpMiddleware({
+        host: testHost,
+        fetch,
+      })
+      nock(testHost)
+        .defaultReplyHeaders({
+          'Content-Type': 'application/json',
+        })
+        .post('/default-header/content-type')
+        .reply(200, { id: 'test-id' })
+
+      httpMiddleware(next)(request, response)
+    }))
+
   test('handle failed response (network error)', () =>
     new Promise((resolve: Function, reject: Function) => {
       const request = createTestRequest({


### PR DESCRIPTION
### Summary

- [x] Fix the `if check` to prevent known headers from being overridden to 'application/json'

### Related Issues
#321 
