### PR TITLE
Upgrade node to version 14

### DIFF
--- a/.changeset/lucky-tomatoes-join.md
+++ b/.changeset/lucky-tomatoes-join.md
@@ -1,0 +1,9 @@
+---
+'@commercetools/history-sdk': major
+'@commercetools/importapi-sdk': major
+'@commercetools/ml-sdk': major
+'@commercetools/platform-sdk': major
+'@commercetools/sdk-client-v2': major
+---
+
+Upgrade node versions to 14 and set engine to >= 14

--- a/packages/history-sdk/package.json
+++ b/packages/history-sdk/package.json
@@ -5,6 +5,9 @@
   },
   "name": "@commercetools/history-sdk",
   "version": "2.6.0",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "Typescript SDK for Composable Commerce Audit Log features",
   "keywords": [
     "commercetools",

--- a/packages/importapi-sdk/package.json
+++ b/packages/importapi-sdk/package.json
@@ -5,6 +5,9 @@
   },
   "name": "@commercetools/importapi-sdk",
   "version": "3.0.1",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "TypeScript SDK for Composable Commerce Import API features",
   "keywords": [
     "commercetools",

--- a/packages/ml-sdk/package.json
+++ b/packages/ml-sdk/package.json
@@ -5,6 +5,9 @@
   },
   "name": "@commercetools/ml-sdk",
   "version": "2.4.2",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "TypeScript SDK for Composable Commerce Machine Learning features",
   "keywords": [
     "commercetools",

--- a/packages/platform-sdk/package.json
+++ b/packages/platform-sdk/package.json
@@ -5,6 +5,9 @@
   },
   "name": "@commercetools/platform-sdk",
   "version": "3.0.2",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "TypeScript definitions and SDK for commercetools Composable Commerce",
   "keywords": ["commercetools", "composable commerce", "typescript", "sdk"],
   "homepage": "https://github.com/commercetools/commercetools-typescript-sdks",

--- a/packages/sdk-client/package.json
+++ b/packages/sdk-client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@commercetools/sdk-client-v2",
   "version": "1.4.2",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "commercetools Composable Commerce TypeScript SDK client.",
   "keywords": [
     "commercetools",


### PR DESCRIPTION
### Summary
Nodejs version 12 is already in `end-of-life` hence a need to upgrade this repository to use node version greater than or equal to 14

### Tasks
- [x] upgrade node version to a minimum of version 14
- [x] add engine to each package to ensure compliance

### Related Issue
#340 