### PR TITLE
feat(http-client): add option to retry a request aborted by timeout

### DIFF
--- a/.changeset/happy-carpets-deliver.md
+++ b/.changeset/happy-carpets-deliver.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sdk-client-v2': minor
+---
+
+Introduce retryOnAbort option to allow retry on timeouts

--- a/packages/sdk-client/src/types/sdk.d.ts
+++ b/packages/sdk-client/src/types/sdk.d.ts
@@ -326,6 +326,7 @@ export type HttpMiddlewareOptions = {
     retryDelay?: number
     backoff?: boolean
     maxDelay?: number
+    retryOnAbort?: boolean
     retryCodes?: Array<number | string>,
   }
   fetch?: any


### PR DESCRIPTION
The current behavior of the client is to retry on a timeout, but immediately abort again due to the re-use of the AbortController. This change does one adjustment and introduces a new option

By default, aborted requests will not be retried.
This is technically a behavioral change, but does not affect the outcome. The reason for this is that the logic did retry, but the http client did immediately abort.

Introduce `retryOnAbort` retry option.
The client continue retries even if it was aborted by a timeout. This is achieved by re-initializing the AbortController. The idea behind this is to allow fast retries for slow request.

Associated to Issue https://github.com/commercetools/commercetools-sdk-typescript/issues/354