### PR TITLE
Fix Uri Not Found on 404 Error

### DIFF
--- a/.changeset/fresh-melons-decide.md
+++ b/.changeset/fresh-melons-decide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sdk-client-v2': patch
+---
+
+fix uri `notfound error` for 404 error when `includeRequestInErrorResponse` is set to false.

--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -30,8 +30,10 @@ function createError({
   ...rest
 }: JsonObject<any>): HttpErrorType {
   let errorMessage = message || 'Unexpected non-JSON error response'
-  if (statusCode === 404)
-    errorMessage = `URI not found: ${rest.originalRequest.uri}`
+  if (statusCode === 404) {
+    errorMessage = `URI not found: ${rest.originalRequest?.uri || rest.uri}`
+    delete rest.uri // remove the `uri` property from the response
+  }
 
   const ResponseError = getErrorByCode(statusCode)
   if (ResponseError) return new ResponseError(errorMessage, rest)
@@ -248,6 +250,8 @@ export default function createHttpMiddleware({
                   statusCode: res.status,
                   ...(includeRequestInErrorResponse
                     ? { originalRequest: request }
+                    : res.status === 404
+                    ? { uri: request.uri }
                     : {}),
                   retryCount,
                   headers: parseHeaders(res.headers),


### PR DESCRIPTION
### Summary

Fix `uri not found error` when `includeRequestInErrorResponse` is set to false

### Related Issues
#414 
