### PR TITLE
Handle node-fetch text parse error in sdk client http middleware

### DIFF
--- a/.changeset/two-flies-lay.md
+++ b/.changeset/two-flies-lay.md
@@ -1,0 +1,6 @@
+---
+'@commercetools/sdk-client-v2': patch
+---
+
+- Handle node-fetch text parse error in sdk client http middleware
+- Adds `catch block` to prevent unhandled promise rejection on parsing response text

--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer/'
-import getErrorByCode, { HttpError, InternalServerError, NetworkError } from '../sdk-client/errors'
+import getErrorByCode, { HttpError, NetworkError } from '../sdk-client/errors'
 import {
   ClientRequest,
   HttpErrorType,

--- a/packages/sdk-client/src/sdk-middleware-http/http.ts
+++ b/packages/sdk-client/src/sdk-middleware-http/http.ts
@@ -190,12 +190,52 @@ export default function createHttpMiddleware({
                   return
                 }
 
-                res.text().then((result) => {
-                  // Try to parse the response as JSON
-                  let parsed
-                  try {
-                    parsed = result.length > 0 ? JSON.parse(result) : {}
-                  } catch (err) {
+                res
+                  .text()
+                  .then((result) => {
+                    // Try to parse the response as JSON
+                    let parsed
+                    try {
+                      parsed = result.length > 0 ? JSON.parse(result) : {}
+                    } catch (err) {
+                      if (enableRetry && retryCount < maxRetries) {
+                        setTimeout(
+                          executeFetch,
+                          calcDelayDuration(
+                            retryCount,
+                            retryDelay,
+                            maxRetries,
+                            backoff,
+                            maxDelay
+                          )
+                        )
+                        retryCount += 1
+                        return
+                      }
+                      parsed = result
+                    }
+
+                    const parsedResponse: any = {
+                      ...response,
+                      body: parsed,
+                      statusCode: res.status,
+                    }
+
+                    if (includeResponseHeaders)
+                      parsedResponse.headers = parseHeaders(res.headers)
+
+                    if (includeOriginalRequest) {
+                      parsedResponse.request = {
+                        ...fetchOptions,
+                      }
+                      maskAuthData(
+                        parsedResponse.request,
+                        maskSensitiveHeaderData
+                      )
+                    }
+                    next(request, parsedResponse)
+                  })
+                  .catch((err) => {
                     if (enableRetry && retryCount < maxRetries) {
                       setTimeout(
                         executeFetch,
@@ -210,45 +250,17 @@ export default function createHttpMiddleware({
                       retryCount += 1
                       return
                     }
-                    parsed = result
-                  }
 
-                  const parsedResponse: any = {
-                    ...response,
-                    body: parsed,
-                    statusCode: res.status,
-                  }
+                    const error = new NetworkError(err.message, {
+                      ...(includeRequestInErrorResponse
+                        ? { originalRequest: request }
+                        : {}),
+                      retryCount,
+                    })
+                    maskAuthData(error.originalRequest, maskSensitiveHeaderData)
 
-                  if (includeResponseHeaders)
-                    parsedResponse.headers = parseHeaders(res.headers)
-
-                  if (includeOriginalRequest) {
-                    parsedResponse.request = {
-                      ...fetchOptions,
-                    }
-                    maskAuthData(
-                      parsedResponse.request,
-                      maskSensitiveHeaderData
-                    )
-                  }
-                  next(request, parsedResponse)
-                }).catch(err => {
-                  if (enableRetry && retryCount < maxRetries) {
-                    setTimeout(executeFetch, calcDelayDuration(retryCount, retryDelay, maxRetries, backoff, maxDelay));
-                    retryCount += 1;
-                    return;
-                  }
-
-                  const error = new NetworkError(err.message, {
-                    ...(includeRequestInErrorResponse
-                      ? { originalRequest: request }
-                      : {}),
-                    retryCount,
+                    next(request, { ...response, error, statusCode: 0 })
                   })
-                  maskAuthData(error.originalRequest, maskSensitiveHeaderData)
-                  
-                  next(request, { ...response, error, statusCode: 0 })
-                });
                 return
               }
 


### PR DESCRIPTION
- Adds catch block to prevent unhandled promise rejection on parsing response text