### PR TITLE
Update SUNRISE data link

### DIFF
--- a/examples/me/README.md
+++ b/examples/me/README.md
@@ -6,7 +6,7 @@ Example to show how the ME endpoints can be used with the TypeScript SDK.
 
 - A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/tutorials/getting-started#creating-an-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
-- If your Project is currently empty, you can install the [SUNRISE sample data](https://docs.commercetools.com/sdk/sunrise-data).
+- If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 
 ## Installation
 


### PR DESCRIPTION
We will be removing the SUNRISE data page from the docs soon, so I'm changing the link to point to the GitHub repo.