### PR TITLE
Fix issues with tsconfig-declaration.json file

### DIFF
--- a/packages/history-sdk/tsconfig-declarations.json
+++ b/packages/history-sdk/tsconfig-declarations.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": false,
+    "isolatedModules": false,
+    "noEmit": false,
+    "allowJs": false,
+    "emitDeclarationOnly": true,
     "paths": {
       "~/*": ["./src/*"],
       "*": ["./src/generated/*"],

--- a/packages/importapi-sdk/tsconfig-declarations.json
+++ b/packages/importapi-sdk/tsconfig-declarations.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": false,
+    "isolatedModules": false,
+    "noEmit": false,
+    "allowJs": false,
+    "emitDeclarationOnly": true,
     "paths": {
       "~/*": ["./src/*"],
       "*": ["./src/generated/*"],

--- a/packages/ml-sdk/tsconfig-declarations.json
+++ b/packages/ml-sdk/tsconfig-declarations.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": false,
+    "isolatedModules": false,
+    "noEmit": false,
+    "allowJs": false,
+    "emitDeclarationOnly": true,
     "paths": {
       "~/*": ["./src/*"],
       "*": ["./src/generated/*"],

--- a/packages/platform-sdk/tsconfig-declarations.json
+++ b/packages/platform-sdk/tsconfig-declarations.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": false,
+    "isolatedModules": false,
+    "noEmit": false,
+    "allowJs": false,
+    "emitDeclarationOnly": true,
     "paths": {
       "~/*": ["./src/*"],
       "*": ["./src/generated/*"],


### PR DESCRIPTION
### Summary
After update of `tsconfig-replace-paths` to version `0.0.14` generator builds started failing. This PR is an attempt to fix this.

### Task completed
- [x] add options to tsconfig-declaration.json file for history import-sdk ml-sdk and platform-sdk