### PR TITLE
Refactor to not use long-lived PAT but short-lived PAT issued by GitHub App

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -11,11 +11,19 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      # Get GitHub token via the CT Changesets App
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+          
       - name: Checkout
         uses: actions/checkout@v3
       - uses: jenschude/auto-create-pr-action@v0.3.1
         with:
           request_title: "Update generated SDKs"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.generate_github_token.outputs.token }}
           request_body: |
             - [ ] Changeset added

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: jenschude/auto-create-pr-action@v0.3.1
         with:
           request_title: "Update generated SDKs"
-          github_token: ${{ secrets.GITHUB_TOKEN }
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           request_body: |
             - [ ] Changeset added

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -11,19 +11,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      # Get GitHub token via the CT Changesets App
-      - name: Generate GitHub token (via CT Changesets App)
-        id: generate_github_token
-        uses: tibdex/github-app-token@v2.1.0
-        with:
-          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
-          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
-          
       - name: Checkout
         uses: actions/checkout@v3
       - uses: jenschude/auto-create-pr-action@v0.3.1
         with:
           request_title: "Update generated SDKs"
-          github_token: ${{ steps.generate_github_token.outputs.token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }
           request_body: |
             - [ ] Changeset added

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Get GitHub token via the CT Changesets App
+      - name: Generate GitHub token (via CT Changesets App)
+        id: generate_github_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
+          private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
+          
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
-          # other workflows
+          # Pass a personal access token (using our CT Changesets App) to be able to trigger other workflows
           # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           # https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/8
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
@@ -62,7 +69,7 @@ jobs:
           version: yarn changeset:version-and-format
           commit: 'ci(changesets): version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Convert markdown to slack markdown
         uses: LoveToKnow/slackify-markdown-action@v1.0.0


### PR DESCRIPTION
#### Summary

Replaces the usage of a static long-lived PAT with a short-lived (auto revoked) PAT through a GitHub Application called CT Changesets.

This is being rolled out across about 10 repositories. More detail and background on the changes can be found on internal documentation.