### PR TITLE
Add headersWithStringBody options

### DIFF
--- a/.changeset/curvy-fans-lick.md
+++ b/.changeset/curvy-fans-lick.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sdk-client-v2': patch
+---
+
+add headersWithStringBody option to httpMiddlewareOptions

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
   coverageDirectory: 'coverage',
   watchPlugins: ['jest-watch-typeahead/filename'],
+  testPathIgnorePatterns: ['packages/platform-sdk/test/integration-tests'],
   reporters: [
     'default',
     process.env.CI === 'true'

--- a/packages/sdk-client/src/types/sdk.d.ts
+++ b/packages/sdk-client/src/types/sdk.d.ts
@@ -100,7 +100,7 @@ export interface ClientRequest {
   uriTemplate?: string
   pathVariables?: VariableMap
   queryParams?: VariableMap
-  body?: any,
+  body?: any
 }
 
 export type ClientResponse<T = any> = {
@@ -275,7 +275,7 @@ type requestBaseOptions = {
   body: string
   basicAuth: string
   pendingTasks: Array<Task>
-  requestState: RequestStateStore,
+  requestState: RequestStateStore
   tokenCache: TokenCache
   tokenCacheKey?: TokenCacheOptions
 }
@@ -321,6 +321,7 @@ export type HttpMiddlewareOptions = {
   includeOriginalRequest?: boolean
   includeRequestInErrorResponse?: boolean
   maskSensitiveHeaderData?: boolean
+  headersWithStringBody?: Array<string>
   timeout?: number
   enableRetry?: boolean
   retryConfig?: {
@@ -329,7 +330,7 @@ export type HttpMiddlewareOptions = {
     backoff?: boolean
     maxDelay?: number
     retryOnAbort?: boolean
-    retryCodes?: Array<number | string>,
+    retryCodes?: Array<number | string>
   }
   fetch?: any
   abortController?: AbortController // deprecated


### PR DESCRIPTION
### Add `headerWithStringBody` options to `httpMiddlewareOptions`

### Tasks completed
- [x] add headersWithStringBody to httpMiddlewareOptions
- [x] add tests