### PR TITLE
Add options for Custom Logger Function

### DIFF
--- a/.changeset/chatty-jobs-melt.md
+++ b/.changeset/chatty-jobs-melt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/sdk-client-v2': minor
+---
+
+Add custom logger function

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "changeset": "changeset",
     "test:unit": "yarn test --testPathIgnorePatterns='packages/platform-sdk/test/integration-tests'",
     "test:integration": "jest --testPathPattern='packages/platform-sdk/test/integration-tests'",
+    "postbuild": "webpack --mode=production",
     "changeset:version-and-format": "changeset version && prettier --write --parser json '**/package.json'"
   },
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "changeset": "changeset",
     "test:unit": "yarn test --testPathIgnorePatterns='packages/platform-sdk/test/integration-tests'",
     "test:integration": "jest --testPathPattern='packages/platform-sdk/test/integration-tests'",
-    "postbuild": "webpack --mode=production",
     "changeset:version-and-format": "changeset version && prettier --write --parser json '**/package.json'"
   },
   "workspaces": ["packages/*"],

--- a/packages/platform-sdk/test/integration-tests/client/client.test.ts
+++ b/packages/platform-sdk/test/integration-tests/client/client.test.ts
@@ -1,11 +1,21 @@
 import { requireEnvVar } from '../../helpers/test-utils'
-import { ClientBuilder, ClientRequest } from '@commercetools/sdk-client-v2/src'
+import {
+  Next,
+  ClientBuilder,
+  ClientRequest,
+  LoggerMiddlewareOptions,
+  MiddlewareRequest,
+  MiddlewareResponse,
+  Middleware,
+} from '@commercetools/sdk-client-v2'
+import { createApiBuilderFromCtpClient } from '@commercetools/platform-sdk'
 import fetch from 'node-fetch'
 
 const projectKey = requireEnvVar('CTP_PROJECT_KEY')
 const clientId = requireEnvVar('CTP_CLIENT_ID')
 const clientSecret = requireEnvVar('CTP_CLIENT_SECRET')
 const authURL = requireEnvVar('CTP_AUTH_URL')
+const apiURL = requireEnvVar('CTP_API_URL')
 
 describe('testing api root client', () => {
   it('should create api root client with anonymous session', async () => {
@@ -47,5 +57,56 @@ describe('testing api root client', () => {
     const response = await client.execute(request)
     expect(response.statusCode).toBe(200)
     expect(response.body.access_token).toBeDefined()
+  })
+
+  it('should create api root client with anonymous session', async () => {
+    const authMiddlewareOptions = {
+      host: authURL,
+      projectKey,
+      credentials: {
+        clientId: clientId,
+        clientSecret: clientSecret,
+      },
+      scopes: [`manage_project:${projectKey}`],
+      fetch,
+    }
+
+    const httpMiddlewareOptions = {
+      host: apiURL,
+      headersWithStringBody: ['application/x-www-form-urlencoded'],
+      fetch,
+    }
+
+    const client = new ClientBuilder()
+      .withProjectKey(projectKey)
+      .withClientCredentialsFlow(authMiddlewareOptions)
+      .withHttpMiddleware(httpMiddlewareOptions)
+      .withLoggerMiddleware({
+        level: 'debug',
+        name: 'test-logger',
+        logger(o): Middleware {
+          return (next: Next): Next => {
+            return (req, res) => {
+              expect(o).toHaveProperty('name')
+              expect(o).toHaveProperty('level')
+              expect(o.name).toEqual('test-logger')
+              expect(o.level).toEqual('debug')
+
+              expect(req.baseUri).toEqual(apiURL)
+              expect(req.uri).toMatch(projectKey)
+
+              expect(res.statusCode).toEqual(200)
+              expect(res.error).toBeUndefined()
+              next(req, res)
+            }
+          }
+        },
+      })
+      .build()
+
+    createApiBuilderFromCtpClient(client)
+      .withProjectKey({ projectKey })
+      .get()
+      .execute()
   })
 })

--- a/packages/platform-sdk/test/integration-tests/client/client.test.ts
+++ b/packages/platform-sdk/test/integration-tests/client/client.test.ts
@@ -3,9 +3,6 @@ import {
   Next,
   ClientBuilder,
   ClientRequest,
-  LoggerMiddlewareOptions,
-  MiddlewareRequest,
-  MiddlewareResponse,
   Middleware,
 } from '@commercetools/sdk-client-v2'
 import { createApiBuilderFromCtpClient } from '@commercetools/platform-sdk'

--- a/packages/platform-sdk/test/integration-tests/process/process.test.ts
+++ b/packages/platform-sdk/test/integration-tests/process/process.test.ts
@@ -123,7 +123,7 @@ describe('integration test for process function', () => {
       .catch(fn)
   })
 
-  test('should properly the `expand` args as a uri parameter', () => {
+  test('should properly `expand` provided queryArgs as a uri parameter', async () => {
     const client = new ClientBuilder()
       .withProjectKey(projectKey)
       .withClientCredentialsFlow(getAuthOptions())
@@ -148,5 +148,5 @@ describe('integration test for process function', () => {
     return client.process(request, fn, {}).then((response) => {
       expect(response[0].statusCode).toEqual(200)
     })
-  })
+  }, 60000)
 })

--- a/packages/platform-sdk/test/integration-tests/test-utils.ts
+++ b/packages/platform-sdk/test/integration-tests/test-utils.ts
@@ -3,6 +3,7 @@ import {
   TokenCache,
   TokenStore,
   TokenCacheOptions,
+  Client,
 } from '@commercetools/sdk-client-v2'
 import { ClientBuilder as ClientBuilderV3 } from '@commercetools/ts-client'
 import { createApiBuilderFromCtpClient } from '../../src'

--- a/packages/sdk-client/src/client-builder/ClientBuilder.ts
+++ b/packages/sdk-client/src/client-builder/ClientBuilder.ts
@@ -20,6 +20,7 @@ import {
   PasswordAuthMiddlewareOptions,
   QueueMiddlewareOptions,
   RefreshAuthMiddlewareOptions,
+  LoggerMiddlewareOptions,
   TelemetryOptions,
 } from '../types/sdk'
 
@@ -180,8 +181,9 @@ export default class ClientBuilder {
     return this
   }
 
-  withLoggerMiddleware() {
-    this.loggerMiddleware = createLoggerMiddleware()
+  withLoggerMiddleware(options?: LoggerMiddlewareOptions): ClientBuilder {
+    const { logger, ...rest } = options || {}
+    this.loggerMiddleware = options?.logger(rest) || createLoggerMiddleware()
     return this
   }
 

--- a/packages/sdk-client/src/client-builder/ClientBuilder.ts
+++ b/packages/sdk-client/src/client-builder/ClientBuilder.ts
@@ -183,7 +183,9 @@ export default class ClientBuilder {
 
   withLoggerMiddleware(options?: LoggerMiddlewareOptions): ClientBuilder {
     const { logger, ...rest } = options || {}
-    this.loggerMiddleware = options?.logger(rest) || createLoggerMiddleware()
+    this.loggerMiddleware =
+      (typeof options?.logger == 'function' && options.logger(rest)) ||
+      createLoggerMiddleware()
     return this
   }
 

--- a/packages/sdk-client/src/types/sdk.d.ts
+++ b/packages/sdk-client/src/types/sdk.d.ts
@@ -359,6 +359,12 @@ export type UserAgentMiddlewareOptions = {
   contactEmail?: string
 }
 
+export type GenericOmit<T, U extends string | number | symbol> = Omit<T, U>;
+export type LoggerMiddlewareOptions = {
+  [key: string]: any;
+  logger: (options?: GenericOmit<LoggerMiddlewareOptions, 'logger'>) => Middleware;
+}
+
 export type Next = (
   request: MiddlewareRequest,
   response: MiddlewareResponse
@@ -538,16 +544,9 @@ export type CorrelationIdMiddlewareOptions = {
   generate: () => string
 }
 
-// // TODO: specify specific options 
-// // export type ApmMiddlewareOptions = Record<string, any>
-// export type ApmMiddlewareOptions = {
-//   createApmMiddleware: (options?: any) => Middleware,
-//   apm: any
-// }
-
 export type TelemetryOptions = {
   apm?: Function;
   tracer?: Function;
   userAgent?: string;
-  createTelemetryMiddleware: (options?: Omit<TelemetryOptions, 'createTelemetryMiddleware'>) => Middleware
+  createTelemetryMiddleware: (options?: GenericOmit<TelemetryOptions, 'createTelemetryMiddleware'>) => Middleware
 }

--- a/packages/sdk-client/test/client-builder.test/client-builder.test.ts
+++ b/packages/sdk-client/test/client-builder.test/client-builder.test.ts
@@ -178,6 +178,18 @@ describe('client builder', () => {
     expect(clientWithTelemetryMiddleware.telemetryMiddleware).toBeTruthy()
   })
 
+  test('should create client with a custom logger function', () => {
+    const client = new ClientBuilder() as any
+    expect(client.loggerMiddleware).toBeFalsy()
+
+    const options = { logger: jest.fn() }
+    const clientWithLoggerMiddleware = client.withLoggerMiddleware(options)
+
+    expect(options.logger).toHaveBeenCalled()
+    expect(options.logger).toBeCalledTimes(1)
+    expect(clientWithLoggerMiddleware.withLoggerMiddleware).toBeTruthy()
+  })
+
   describe('builder method', () => {
     test('build client', () => {
       const client = new ClientBuilder()
@@ -199,6 +211,7 @@ describe('client builder', () => {
           tracer: jest.fn(),
           createTelemetryMiddleware: (): Middleware => jest.fn(),
         })
+        .withLoggerMiddleware({ logger: jest.fn() })
         .build()
 
       expect(client).toBeTruthy()


### PR DESCRIPTION
### Summary

Add options that includer a `logger` function to be executed in place of the default

### Tasks Completed

- [x] add option to include a custom logger middleware
- [x] add tests to validate functionality

### Fixes
The PR fixes issue #653 

### Dev Notes
This implementation can be used as follows:

```ts
import {
  ...
  type Next,
  type Client,
  type MiddlewareRequest,
  type LoggerMiddlewareOptions,
  type MiddlewareResponse,
} from '@commercetools/sdk-client-v2';

const client: Client = new ClientBuilder()
  .withProjectKey(projectKey)
  ...
  .withLoggerMiddleware({
    level: 'debug',
    name: 'custom-logger-fn',
    logger(options?: LoggerMiddlewareOptions) {
     return (next: Next): Next => {
        return (req: MiddlewareRequest, res: MiddlewareResponse) => {
          console.log(options);  // this will log all included option except the logger function i.e { level: 'debug', name: 'custom-logger-fn' }
          console.log(req, res);
          next(req, res);
        }
      }
    }
  }).build()

```