### PR TITLE
Increase Jest Max Worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generate": "manypkg run generate && yarn format",
     "format": "prettier --write '**/*.{js,ts,json,md}'",
     "build": "preconstruct build",
-    "test": "jest --maxWorkers=2",
+    "test": "jest --maxWorkers=3",
     "coverage": "codecov",
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generate": "manypkg run generate && yarn format",
     "format": "prettier --write '**/*.{js,ts,json,md}'",
     "build": "preconstruct build",
-    "test": "jest --maxWorkers=1",
+    "test": "jest --runInBand",
     "coverage": "codecov",
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generate": "manypkg run generate && yarn format",
     "format": "prettier --write '**/*.{js,ts,json,md}'",
     "build": "preconstruct build",
-    "test": "jest --maxWorkers=3",
+    "test": "jest --maxWorkers=1",
     "coverage": "codecov",
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",


### PR DESCRIPTION
### Summary
Attempt to fix jest circle-ci repeated SIGKILL signal on node version 16


### Tasks Completed
- [x] Remove `--maxWorkers` CLI options.
- [x] Add `--runInBand` CLI option 

### Devs Note

For some reason, node v16 is consuming excessive amount of memory. Rather than spend too much time debugging this issue, I think it will be wise to `temporarily` disable the parallelisation of the tests using `workers` this is because a plan is already underway to remove support for node v16.

Also, after the node version update, we will definitely go back to parallelising the tests once again.