### PR TITLE
fix(tests): check before create new product type

### DIFF
--- a/packages/platform-sdk/test/integration-tests/cart/cart.me.test.ts
+++ b/packages/platform-sdk/test/integration-tests/cart/cart.me.test.ts
@@ -27,7 +27,6 @@ const apiUrl = requireEnvVar('CTP_API_URL')
 
 describe('testing me endpoint cart', () => {
   let anonymousApiRoot: ByProjectKeyRequestBuilder
-  let productType
 
   beforeAll(async () => {
     const ctpClient = new ClientBuilder()
@@ -56,16 +55,6 @@ describe('testing me endpoint cart', () => {
         .delete({ queryArgs: { version: cart.version } })
         .execute()
     }
-
-    productType = await ensureProductType(productTypeDraftForProduct)
-  })
-
-  afterAll(async () => {
-    await apiRoot
-      .productTypes()
-      .withId({ ID: productType.id })
-      .delete({ queryArgs: { version: productType.version } })
-      .execute()
   })
 
   it('should create cart using me endpoint and anonymous session', async () => {
@@ -87,6 +76,7 @@ describe('testing me endpoint cart', () => {
   // https://github.com/commercetools/commercetools-sdk-typescript/issues/446
   it('should expand active cart using me endpoint in a store', async () => {
     const category = await createCategory()
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const taxCategory = await ensureTaxCategory()
 
     const productDraft = await createProductDraft(

--- a/packages/platform-sdk/test/integration-tests/cart/cart.me.test.ts
+++ b/packages/platform-sdk/test/integration-tests/cart/cart.me.test.ts
@@ -14,7 +14,7 @@ import { apiRoot } from '../test-utils'
 import { createCategory } from '../category/category-fixture'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import { createProduct, createProductDraft } from '../product/product-fixture'
@@ -27,6 +27,7 @@ const apiUrl = requireEnvVar('CTP_API_URL')
 
 describe('testing me endpoint cart', () => {
   let anonymousApiRoot: ByProjectKeyRequestBuilder
+  let productType
 
   beforeAll(async () => {
     const ctpClient = new ClientBuilder()
@@ -55,6 +56,16 @@ describe('testing me endpoint cart', () => {
         .delete({ queryArgs: { version: cart.version } })
         .execute()
     }
+
+    productType = await ensureProductType(productTypeDraftForProduct)
+  })
+
+  afterAll(async () => {
+    await apiRoot
+      .productTypes()
+      .withId({ ID: productType.id })
+      .delete({ queryArgs: { version: productType.version } })
+      .execute()
   })
 
   it('should create cart using me endpoint and anonymous session', async () => {
@@ -77,7 +88,6 @@ describe('testing me endpoint cart', () => {
   it('should expand active cart using me endpoint in a store', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
 
     const productDraft = await createProductDraft(
       category,

--- a/packages/platform-sdk/test/integration-tests/cart/cart.test.ts
+++ b/packages/platform-sdk/test/integration-tests/cart/cart.test.ts
@@ -42,8 +42,7 @@ import { createType, deleteType } from '../type/type-fixture'
 import { createCategory, deleteCategory } from '../category/category-fixture'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
-  deleteProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import {
@@ -85,7 +84,7 @@ describe('testing cart API calls', () => {
   it('should create a cart with line items', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
 
     //Published product
     const productDraft1 = await createProductDraft(
@@ -126,7 +125,6 @@ describe('testing cart API calls', () => {
     await deleteCart(cart)
     await deleteProduct(product1)
     await deleteProduct(product2)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 

--- a/packages/platform-sdk/test/integration-tests/graphql/graphql.test.ts
+++ b/packages/platform-sdk/test/integration-tests/graphql/graphql.test.ts
@@ -2,8 +2,8 @@ import { apiRoot } from '../test-utils'
 import { createCategory, deleteCategory } from '../category/category-fixture'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
   deleteProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import {
@@ -17,7 +17,7 @@ describe('testing graphQL API calls', () => {
   it('should make a graphQL request with string', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -48,7 +48,6 @@ describe('testing graphQL API calls', () => {
     expect(graphQLResponse).not.toBe(null)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 })

--- a/packages/platform-sdk/test/integration-tests/message/message.test.ts
+++ b/packages/platform-sdk/test/integration-tests/message/message.test.ts
@@ -6,8 +6,7 @@ import {
 import { createCategory, deleteCategory } from '../category/category-fixture'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
-  deleteProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import { apiRoot } from '../test-utils'
@@ -16,7 +15,7 @@ describe('testing message API calls', () => {
   it('should get a message', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = createProductDraft(
       category,
       taxCategory,
@@ -25,7 +24,6 @@ describe('testing message API calls', () => {
     )
     const product = await createProduct(productDraft)
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
 
     const message = await apiRoot.messages().get().execute()
@@ -36,7 +34,7 @@ describe('testing message API calls', () => {
   it('should get a message by Id', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = createProductDraft(
       category,
       taxCategory,
@@ -63,7 +61,6 @@ describe('testing message API calls', () => {
       expect(message.body).not.toBe(null)
       expect(message.body.id).toEqual(messageId)
 
-      await deleteProductType(productType)
       await deleteCategory(category)
     } catch (e) {
       /** noop */

--- a/packages/platform-sdk/test/integration-tests/order/order.test.ts
+++ b/packages/platform-sdk/test/integration-tests/order/order.test.ts
@@ -3,8 +3,8 @@ import { createOrder, deleteOrder } from './order-fixture'
 import { createCategory, deleteCategory } from '../category/category-fixture'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
   deleteProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import {
@@ -21,7 +21,7 @@ describe('testing order API calls', () => {
   it('should get a order by Id', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -65,14 +65,13 @@ describe('testing order API calls', () => {
       .execute()
     await deleteCart(getCart)
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should get a order by order number', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -116,14 +115,13 @@ describe('testing order API calls', () => {
       .execute()
     await deleteCart(getCart)
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should update a order', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -183,7 +181,6 @@ describe('testing order API calls', () => {
       .execute()
     await deleteCart(getCart)
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
@@ -208,7 +205,7 @@ describe('testing order API calls', () => {
 
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -279,7 +276,6 @@ describe('testing order API calls', () => {
       .execute()
     await deleteCart(getCart)
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   }, 50_000)
 })

--- a/packages/platform-sdk/test/integration-tests/product-projection/product-projection.test.ts
+++ b/packages/platform-sdk/test/integration-tests/product-projection/product-projection.test.ts
@@ -2,8 +2,7 @@ import { apiRoot } from '../test-utils'
 import { createCategory, deleteCategory } from '../category/category-fixture'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
-  deleteProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import {
@@ -17,7 +16,7 @@ describe('testing product projection API calls', () => {
   it('should get a product by Id', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -40,14 +39,13 @@ describe('testing product projection API calls', () => {
     expect(productProjectionResponse.body.id).toEqual(product.body.id)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should get a product by key', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -106,14 +104,13 @@ describe('testing product projection API calls', () => {
     ).toEqual({ key: 'test', label: 'test' })
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should query a product by product projection', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -136,14 +133,13 @@ describe('testing product projection API calls', () => {
     )
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should search a product by product projection', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -181,7 +177,6 @@ describe('testing product projection API calls', () => {
     expect(productProjectionSearchResponse.body.facets).not.toBe(null)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   }, 40_000)
 })

--- a/packages/platform-sdk/test/integration-tests/product-type/product-type-fixture.ts
+++ b/packages/platform-sdk/test/integration-tests/product-type/product-type-fixture.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { apiRoot } from '../test-utils'
 import { AttributeDefinitionDraft, ProductTypeDraft } from '../../../src'
+import { createTaxCategory } from '../tax-category/tax-category-fixture'
 
 const attributeDefinitionDraft: AttributeDefinitionDraft = {
   type: {
@@ -91,17 +92,38 @@ const productTypeDraft: ProductTypeDraft = {
 }
 
 export const productTypeDraftForProduct: ProductTypeDraft = {
-  key: 'test-productType-key-' + randomUUID(),
+  key: 'test-productTypeForProduct-key',
   name: 'test-name-productType-' + randomUUID(),
   description: 'test-productType-description-' + randomUUID(),
   attributes: attributeDefinitionDraftProduct,
 }
 
-export const createProductType = async (productTypeDraftBody?) => {
+export const ensureProductType = async (productTypeDraftBody?) => {
+  try {
+    return await apiRoot
+      .productTypes()
+      .withKey({ key: productTypeDraftBody?.key || productTypeDraft.key })
+      .get()
+      .execute()
+  } catch (e) {
+    return await createProductType(productTypeDraftBody || productTypeDraft)
+  }
+}
+
+const createProductType = async (productTypeDraftBody?) => {
   return await apiRoot
     .productTypes()
     .post({ body: productTypeDraftBody || productTypeDraft })
     .execute()
+}
+
+export const createRandomProductType = async () => {
+  return await createProductType({
+    key: 'test-productType-key-' + randomUUID(),
+    name: 'test-name-productType-' + randomUUID(),
+    description: 'test-productType-description-' + randomUUID(),
+    attributes: attributeDefinitionDraftProduct,
+  })
 }
 
 export const deleteProductType = async (responseCreatedProductType) => {

--- a/packages/platform-sdk/test/integration-tests/product-type/product-type.test.ts
+++ b/packages/platform-sdk/test/integration-tests/product-type/product-type.test.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'crypto'
 import { apiRoot } from '../test-utils'
 import { AttributeDefinitionDraft, ProductTypeDraft } from '../../../src'
-import { createProductType, deleteProductType } from './product-type-fixture'
+import {
+  ensureProductType,
+  deleteProductType,
+  createRandomProductType,
+} from './product-type-fixture'
 
 describe('testing product type API calls', () => {
   it('should create and delete a product type by ID', async () => {
@@ -45,7 +49,7 @@ describe('testing product type API calls', () => {
   })
 
   it('should get a product type by ID', async () => {
-    const productType = await createProductType()
+    const productType = await ensureProductType()
 
     const getProductType = await apiRoot
       .productTypes()
@@ -60,7 +64,7 @@ describe('testing product type API calls', () => {
   })
 
   it('should get a product type by key', async () => {
-    const productType = await createProductType()
+    const productType = await ensureProductType()
 
     const getProductType = await apiRoot
       .productTypes()
@@ -75,7 +79,7 @@ describe('testing product type API calls', () => {
   })
 
   it('should query a product type', async () => {
-    const productType = await createProductType()
+    const productType = await ensureProductType()
     const queryProductType = await apiRoot
       .productTypes()
       .get({
@@ -91,7 +95,7 @@ describe('testing product type API calls', () => {
   })
 
   it('should update a product type by Id', async () => {
-    const productType = await createProductType()
+    const productType = await createRandomProductType()
 
     const updateProductType = await apiRoot
       .productTypes()
@@ -116,7 +120,7 @@ describe('testing product type API calls', () => {
   })
 
   it('should update a product type by Key', async () => {
-    const productType = await createProductType()
+    const productType = await createRandomProductType()
 
     const updateProductType = await apiRoot
       .productTypes()
@@ -141,7 +145,7 @@ describe('testing product type API calls', () => {
   })
 
   it('should delete a product type by Key', async () => {
-    const productType = await createProductType()
+    const productType = await createRandomProductType()
 
     const responseProductTypeDeleted = await apiRoot
       .productTypes()

--- a/packages/platform-sdk/test/integration-tests/product/product.test.ts
+++ b/packages/platform-sdk/test/integration-tests/product/product.test.ts
@@ -2,8 +2,7 @@ import { randomUUID } from 'crypto'
 import { apiRoot } from '../test-utils'
 import { ensureTaxCategory } from '../tax-category/tax-category-fixture'
 import {
-  createProductType,
-  deleteProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import {
@@ -33,7 +32,7 @@ describe('testing product API calls', () => {
   it('should create and delete a product by ID', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
 
     const productTypeResourceIdentifier: ProductTypeResourceIdentifier = {
       typeId: 'product-type',
@@ -155,14 +154,13 @@ describe('testing product API calls', () => {
 
     expect(responseProductDeleted.statusCode).toEqual(200)
 
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should get a product by Id', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -181,14 +179,13 @@ describe('testing product API calls', () => {
     expect(getProduct.body.id).toEqual(product.body.id)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should get a product by key', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -207,14 +204,13 @@ describe('testing product API calls', () => {
     expect(getProduct.body.key).toEqual(product.body.key)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should get a product by SKU using query predicates', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -241,14 +237,13 @@ describe('testing product API calls', () => {
     expect(getProduct.body.results[0].key).toEqual(product.body.key)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should update a product by Id', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -277,14 +272,13 @@ describe('testing product API calls', () => {
     expect(updateProduct.statusCode).toEqual(200)
 
     await deleteProduct(updateProduct)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should update a product by key', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -313,14 +307,13 @@ describe('testing product API calls', () => {
     expect(updateProduct.statusCode).toEqual(200)
 
     await deleteProduct(updateProduct)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
   it('should query a product', async () => {
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,
@@ -340,7 +333,6 @@ describe('testing product API calls', () => {
     expect(queryProduct.body.results[0].id).toEqual(product.body.id)
 
     await deleteProduct(product)
-    await deleteProductType(productType)
     await deleteCategory(category)
   })
 
@@ -349,7 +341,7 @@ describe('testing product API calls', () => {
     const imageFile = await fs.readFile(imagePath)
     const category = await createCategory()
     const taxCategory = await ensureTaxCategory()
-    const productType = await createProductType(productTypeDraftForProduct)
+    const productType = await ensureProductType(productTypeDraftForProduct)
     const productDraft = await createProductDraft(
       category,
       taxCategory,

--- a/packages/platform-sdk/test/integration-tests/sdk-v3/middlewares.test.ts
+++ b/packages/platform-sdk/test/integration-tests/sdk-v3/middlewares.test.ts
@@ -5,7 +5,7 @@ import {
   projectKey,
 } from '../test-utils'
 import {
-  createProductType,
+  ensureProductType,
   productTypeDraftForProduct,
 } from '../product-type/product-type-fixture'
 import {
@@ -36,7 +36,7 @@ describe('Concurrent Modification Middleware', () => {
   beforeAll(async () => {
     category = await createCategory()
     taxCategory = await ensureTaxCategory()
-    productType = await createProductType(productTypeDraftForProduct)
+    productType = await ensureProductType(productTypeDraftForProduct)
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
There was an issue that more than 1000 product types were created. This is the limit of CTP: https://docs.commercetools.com/api/limits#product-types. So, we need to ensure that the product type is created only if it does not exist. This PR checks if the product type exists before creating a new one.
