### PR TITLE
[DEVX-434][FIX] Fix Typo Error in Executor Function

### DIFF
--- a/.changeset/hot-pans-exercise.md
+++ b/.changeset/hot-pans-exercise.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/ts-client': patch
+---
+
+Fix type error in executor function headers options

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/auth-request-executor.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/auth-request-executor.ts
@@ -88,7 +88,7 @@ export async function executeRequest(
       headers: {
         Authorization: `Basic ${basicAuth}`,
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Conent-Length': Buffer.byteLength(body).toString(),
+        'Content-Length': Buffer.byteLength(body).toString(),
       },
       httpClient,
       body,


### PR DESCRIPTION
### Summary
Fix Typo error in `executor` function `Content-Length` headers entry.

### Completed Tasks
- [x] fix typo error in executor function header options