### PR TITLE
[Feat][DEVX-487] Add `httpClient` configuration options

### DIFF
--- a/packages/platform-sdk/test/integration-tests/test-utils.ts
+++ b/packages/platform-sdk/test/integration-tests/test-utils.ts
@@ -53,7 +53,7 @@ export const authMiddlewareOptions = {
   },
   tokenCache,
   scopes: [`manage_project:${projectKey}`],
-  fetch,
+  httpClient: fetch,
 }
 
 export const authMiddlewareOptionsV3 = {

--- a/packages/sdk-client-v3/src/client/builder.ts
+++ b/packages/sdk-client-v3/src/client/builder.ts
@@ -75,6 +75,7 @@ export default class ClientBuilder {
       host: oauthUri,
       projectKey: projectKey || this.projectKey,
       credentials,
+      httpClient: httpClient || fetch,
       scopes,
     }).withHttpMiddleware({
       host: baseUri,

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/anonymous-session-flow.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/anonymous-session-flow.ts
@@ -56,6 +56,7 @@ export default function createAuthMiddlewareForAnonymousSessionFlow(
         tokenCache,
         tokenCacheKey,
         httpClient: options.httpClient || fetch,
+        httpClientOptions: options.httpClientOptions,
         ...buildRequestForAnonymousSessionFlow(options),
         userOption: options,
         next,

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/auth-request-executor.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/auth-request-executor.ts
@@ -12,7 +12,13 @@ import {
 import { buildRequestForRefreshTokenFlow } from './auth-request-builder'
 
 export async function executeRequest(options: executeRequestOptions) {
-  const { httpClient, tokenCache, userOption, tokenCacheObject } = options
+  const {
+    httpClient,
+    httpClientOptions,
+    tokenCache,
+    userOption,
+    tokenCacheObject,
+  } = options
 
   let url = options.url
   let body = options.body
@@ -62,6 +68,7 @@ export async function executeRequest(options: executeRequestOptions) {
         'Content-Length': byteLength(body),
       },
       httpClient,
+      httpClientOptions,
       body,
     })
 

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/client-credentials-flow.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/client-credentials-flow.ts
@@ -57,6 +57,7 @@ export default function createAuthMiddlewareForClientCredentialsFlow(
         tokenCacheKey,
         tokenCacheObject,
         httpClient: options.httpClient || fetch,
+        httpClientOptions: options.httpClientOptions,
         ...buildRequestForClientCredentialsFlow(options),
         next,
       }

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/password-flow.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/password-flow.ts
@@ -53,6 +53,7 @@ export default function createAuthMiddlewareForPasswordFlow(
         tokenCache,
         tokenCacheKey,
         httpClient: options.httpClient || fetch,
+        httpClientOptions: options.httpClientOptions,
         ...buildRequestForPasswordFlow(options),
         userOption: options,
         next,

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/refresh-token-flow.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/refresh-token-flow.ts
@@ -51,6 +51,7 @@ export default function createAuthMiddlewareForRefreshTokenFlow(
         request,
         tokenCache,
         httpClient: options.httpClient || fetch,
+        httpClientOptions: options.httpClientOptions,
         ...buildRequestForRefreshTokenFlow(options),
         next,
       }

--- a/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
+++ b/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
@@ -22,7 +22,7 @@ import {
   getHeaders,
   isBuffer,
   maskAuthData,
-  validateHttpOptions,
+  validateHttpClientOptions,
 } from '../utils'
 
 async function executeRequest({
@@ -142,7 +142,7 @@ export default function createHttpMiddleware(
   options: HttpMiddlewareOptions
 ): Middleware {
   // validate response
-  validateHttpOptions(options)
+  validateHttpClientOptions(options)
 
   const {
     host,

--- a/packages/sdk-client-v3/src/types/types.d.ts
+++ b/packages/sdk-client-v3/src/types/types.d.ts
@@ -98,8 +98,9 @@ export type AuthMiddlewareOptions = {
   scopes?: Array<string>
   // For internal usage only
   oauthUri?: string
-  httpClient?: Function
   tokenCache?: TokenCache
+  httpClient: Function
+  httpClientOptions?: object
 }
 
 export type TokenCacheOptions = {
@@ -138,7 +139,8 @@ export type RefreshAuthMiddlewareOptions = {
   tokenCache?: TokenCache,
   // For internal usage only
   oauthUri?: string
-  httpClient?: Function
+  httpClient: Function
+  httpClientOptions?: object
 }
 
 /* Request */
@@ -147,9 +149,10 @@ type requestBaseOptions = {
   body: string
   basicAuth: string
   request: MiddlewareRequest
-  tokenCache: TokenCache,
-  tokenCacheKey?: TokenCacheOptions,
+  tokenCache: TokenCache
+  tokenCacheKey?: TokenCacheOptions
   tokenCacheObject?: TokenStore
+  httpClientOptions?: object
 }
 
 export type executeRequestOptions = requestBaseOptions & {
@@ -160,10 +163,8 @@ export type executeRequestOptions = requestBaseOptions & {
 
 export type AuthMiddlewareBaseOptions = requestBaseOptions & {
   request: MiddlewareRequest
-  httpClient?: Function
+  httpClient: Function
 }
-
-export type RequestState = boolean
 
 export type Task = {
   request: MiddlewareRequest
@@ -187,7 +188,8 @@ export type PasswordAuthMiddlewareOptions = {
   tokenCache?: TokenCache,
   // For internal usage only
   oauthUri?: string
-  httpClient?: Function
+  httpClient: Function
+  httpClientOptions?: object
 }
 
 export type TokenInfo = {
@@ -214,8 +216,8 @@ export type HttpMiddlewareOptions = {
   enableRetry?: boolean
   retryConfig?: RetryOptions
   httpClient: Function
-  getAbortController?: () => AbortController
   httpClientOptions?: object // will be passed as a second argument to your httpClient function for configuration
+  getAbortController?: () => AbortController
 }
 
 export type RetryOptions = RetryMiddlewareOptions
@@ -297,6 +299,7 @@ export type IClientOptions = {
   enableRetry?: boolean
   retryConfig?: RetryOptions
   maskSensitiveHeaderData?: boolean
+  httpClientOptions?: object
 }
 
 export type HttpClientOptions = IClientOptions & Optional

--- a/packages/sdk-client-v3/src/utils/executor.ts
+++ b/packages/sdk-client-v3/src/utils/executor.ts
@@ -56,11 +56,10 @@ export default async function executor(request: HttpClientConfig) {
 
       async function execute() {
         return httpClient(url, {
-          ...rest,
           ...options,
+          ...rest,
           headers: {
             ...rest.headers,
-            ...options.headers,
 
             // axios header encoding
             'Accept-Encoding': 'application/json',
@@ -156,7 +155,9 @@ export default async function executor(request: HttpClientConfig) {
      * middleware options or from
      * http client config
      */
-    {}
+
+    // we want to suppress axios internal error handling behaviour
+    { validateStatus: (status: number) => true }
   )
 
   return data

--- a/packages/sdk-client-v3/src/utils/index.ts
+++ b/packages/sdk-client-v3/src/utils/index.ts
@@ -20,5 +20,5 @@ export { default as userAgent } from './userAgent'
 export {
     validate,
     // validateUserAgentOptions,
-    validateClient, validateHttpOptions, validateRetryCodes
+    validateClient, validateHttpClientOptions, validateRetryCodes
 } from './validate'

--- a/packages/sdk-client-v3/src/utils/validate.ts
+++ b/packages/sdk-client-v3/src/utils/validate.ts
@@ -9,7 +9,7 @@ import {
  * validate some essential http options
  * @param options
  */
-export function validateHttpOptions(options: HttpMiddlewareOptions) {
+export function validateHttpClientOptions(options: HttpMiddlewareOptions) {
   if (!options.host)
     throw new Error(
       'Request `host` or `url` is missing or invalid, please pass in a valid host e.g `host: http://a-valid-host-url`'
@@ -19,6 +19,14 @@ export function validateHttpOptions(options: HttpMiddlewareOptions) {
     throw new Error(
       'An `httpClient` is not available, please pass in a `fetch` or `axios` instance as an option or have them globally available.'
     )
+
+  if (
+    options.httpClientOptions &&
+    Object.prototype.toString.call(options.httpClientOptions) !==
+      '[object Object]'
+  ) {
+    throw new Error('`httpClientOptions` must be an object type')
+  }
 }
 
 /**

--- a/packages/sdk-client-v3/tests/auth/auth-request-executor.test.ts
+++ b/packages/sdk-client-v3/tests/auth/auth-request-executor.test.ts
@@ -211,5 +211,61 @@ describe('Auth request executor', () => {
         expect(err.message).toEqual('an error occurred.')
       }
     })
+
+    test('should call the httpClient using the provided `httpClientOptions`', async () => {
+      const options = createTestExecutorOptions({
+        url: 'test-demo-uri',
+        tokenCache: cache(),
+        httpClientOptions: { name: 'httpClientOptions' },
+        httpClient: jest.fn(() => ({
+          statusCode: 200,
+          data: {
+            statusCode: 200,
+            access_token: 'test-access-token',
+          },
+        })),
+      })
+
+      await executeRequest(options)
+      expect(options.httpClient).toHaveBeenCalledWith(
+        options.url,
+        expect.objectContaining({
+          httpClientOptions: expect.objectContaining({
+            name: 'httpClientOptions',
+          }),
+        })
+      )
+    })
+
+    test('should inject header options using `httpClientOptions`', async () => {
+      const options = createTestExecutorOptions({
+        url: 'test-demo-uri',
+        tokenCache: cache(),
+        httpClientOptions: {
+          name: 'httpClientOptions',
+          headers: { withClientOptions: true },
+        },
+        httpClient: jest.fn(() => ({
+          statusCode: 200,
+          data: {
+            statusCode: 200,
+            access_token: 'test-access-token',
+          },
+        })),
+      })
+
+      await executeRequest(options)
+      expect(options.httpClient).toHaveBeenCalledWith(
+        options.url,
+        expect.objectContaining({
+          httpClientOptions: expect.objectContaining({
+            name: 'httpClientOptions',
+            headers: expect.objectContaining({
+              withClientOptions: true,
+            }),
+          }),
+        })
+      )
+    })
   })
 })


### PR DESCRIPTION
### Summary
Add options to configure individual http client instances.

### Completed Tasks
- [x] add config object to auth and http middleware options
- [x] pass options down to request executor functions
- [x] add object validation to ensure option is truly an object
- [x] add unit and integration tests
- [x] minor refactor