### PR TITLE
[Fix][DEVX-514] Fix v3 AbortController Retry Reinitialization

### DIFF
--- a/.changeset/grumpy-ways-drum.md
+++ b/.changeset/grumpy-ways-drum.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/ts-client": patch
+---
+
+[Fix][DEVX-514] Fix v3 AbortController Retry Reinitialization

--- a/packages/platform-sdk/test/integration-tests/sdk-v3/error-cases.test.ts
+++ b/packages/platform-sdk/test/integration-tests/sdk-v3/error-cases.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../test-utils'
 import { createApiBuilderFromCtpClient } from '../../../src'
 import fetch from 'node-fetch'
+import { TokenCache } from '@commercetools/ts-client'
 
 describe('testing error cases', () => {
   it('should throw error when a product type is not found', async () => {
@@ -63,4 +64,46 @@ describe('testing error cases', () => {
 
     expect(response.statusCode).toBe(200)
   })
+
+  // This test is skipped because currently I don‘t know how to verify its correctness, so this is only for manual testing
+  it.skip('should retry correctly multiple times when aborted', async () => {
+    const client = new ClientBuilderV3()
+      .withClientCredentialsFlow({
+        ...authMiddlewareOptionsV3,
+        projectKey: 'a',
+        credentials: {
+          clientId: 'test',
+          clientSecret: 'test',
+        },
+        tokenCache: {
+          set: (cache) => {
+            console.log(cache)
+          },
+          get: (tokenCacheKey) => {
+            return {
+              token: 'test',
+              expirationTime: 9934431427363,
+            }
+          },
+        } as TokenCache,
+      })
+      .withHttpMiddleware({
+        ...httpMiddlewareOptionsV3,
+        host: 'https://example.com:81',
+        enableRetry: true,
+        timeout: 10000,
+        retryConfig: {
+          retryOnAbort: true,
+          maxRetries: 4,
+          retryDelay: 400,
+          retryCodes: [401],
+        },
+      })
+      .build()
+
+    const apiRootV3 = createApiBuilderFromCtpClient(client).withProjectKey({
+      projectKey,
+    })
+    await apiRootV3.get().execute()
+  }, 999999999)
 })

--- a/packages/sdk-client-v3/README.md
+++ b/packages/sdk-client-v3/README.md
@@ -1,4 +1,4 @@
-# Commercetools Composable Commerce (Improved) TypeScript SDK client (beta)
+# Commercetools Composable Commerce (Improved) TypeScript SDK client
 
 This is the new and improved Typescript SDK client.
 

--- a/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
+++ b/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
@@ -151,13 +151,6 @@ export default function createHttpMiddleware(
 
   return (next: Next) => {
     return async (request: MiddlewareRequest): Promise<MiddlewareResponse> => {
-      let abortController: AbortController
-
-      if (timeout || getAbortController)
-        abortController =
-          (getAbortController ? getAbortController() : null) ||
-          new AbortController()
-
       const url = host.replace(/\/$/, '') + request.uri
       const requestHeader: JsonObject<QueryParam> = { ...request.headers }
 
@@ -206,13 +199,9 @@ export default function createHttpMiddleware(
         clientOptions.credentialsMode = credentialsMode
       }
 
-      if (abortController) {
-        clientOptions.signal = abortController.signal
-      }
-
       if (timeout) {
         clientOptions.timeout = timeout
-        clientOptions.abortController = abortController
+        clientOptions.getAbortController = getAbortController
       }
 
       if (body) {

--- a/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
+++ b/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
@@ -30,23 +30,14 @@ async function executeRequest({
   httpClient,
   clientOptions,
 }: HttpOptions): Promise<ClientResult> {
-  let timer: ReturnType<typeof setTimeout>
-
   const {
-    timeout,
     request,
-    abortController,
     maskSensitiveHeaderData,
     includeRequestInErrorResponse,
     includeResponseHeaders,
   } = clientOptions
 
   try {
-    if (timeout)
-      timer = setTimeout(() => {
-        abortController.abort()
-      }, timeout)
-
     const response: TResponse = await executor({
       url,
       ...clientOptions,
@@ -134,8 +125,6 @@ async function executeRequest({
       body: null,
       error,
     }
-  } finally {
-    clearTimeout(timer)
   }
 }
 

--- a/packages/sdk-client-v3/src/types/types.d.ts
+++ b/packages/sdk-client-v3/src/types/types.d.ts
@@ -1,4 +1,4 @@
-import AbortController from 'abort-controller'
+import AbortController, {AbortSignal} from 'abort-controller'
 
 export type Nullable<T> = T | null
 export type Keys = string | number | symbol
@@ -295,6 +295,8 @@ export type IClientOptions = {
   body?: Record<string, any> | string | Uint8Array;
   timeout?: number
   abortController?: AbortController
+  signal?: AbortSignal,
+  getAbortController?: () => AbortController
   includeOriginalRequest?: boolean
   enableRetry?: boolean
   retryConfig?: RetryOptions


### PR DESCRIPTION
### Summary
Fix issue with abortController always reusing the inital timedout controller

### Completed Tasks
- [x] fix issue with abortController not reinitialized for each request

### Support Ticket
[#30038](https://commercetools.atlassian.net/browse/SUPPORT-30038?focusedCommentId=865938)


### TODO
- [ ] Include tests