### PR TITLE
[Fix] Issue with `process` Object in a non supported environments e.g React Native

### DIFF
--- a/.changeset/rare-feet-cheat.md
+++ b/.changeset/rare-feet-cheat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/ts-client': patch
+---
+
+Fix issue with user-agents in `unknown` environments e.g react-native

--- a/packages/sdk-client-v3/src/utils/userAgent.ts
+++ b/packages/sdk-client-v3/src/utils/userAgent.ts
@@ -16,8 +16,8 @@ const isBrowser = (): boolean =>
 function getSystemInfo(): string {
   if (isBrowser()) return window.navigator.userAgent
 
-  const nodeVersion: string = process?.version.slice(1) || 'unknow' // unknow environment like  React Native etc
-  const platformInfo = `(${process.platform}; ${process.arch})`
+  const nodeVersion: string = process?.version?.slice(1) || 'unknow' // unknow environment like  React Native etc
+  const platformInfo = `(${process?.platform}; ${process?.arch})`
 
   return `node.js/${nodeVersion} ${platformInfo}`
 }

--- a/packages/sdk-client-v3/src/utils/userAgent.ts
+++ b/packages/sdk-client-v3/src/utils/userAgent.ts
@@ -19,7 +19,7 @@ function getSystemInfo(): string {
   const nodeVersion: string = process?.version?.slice(1) || 'unknow' // unknow environment like  React Native etc
   const platformInfo = `(${process?.platform || ''}; ${process?.arch || ''})`
 
-  return `node.js/${nodeVersion} ${platformInfo}`
+  return `node.js/${nodeVersion} ${platformInfo.trim()}`
 }
 
 export default function createUserAgent(options: HttpUserAgentOptions) {

--- a/packages/sdk-client-v3/src/utils/userAgent.ts
+++ b/packages/sdk-client-v3/src/utils/userAgent.ts
@@ -17,7 +17,7 @@ function getSystemInfo(): string {
   if (isBrowser()) return window.navigator.userAgent
 
   const nodeVersion: string = process?.version?.slice(1) || 'unknow' // unknow environment like  React Native etc
-  const platformInfo = `(${process?.platform}; ${process?.arch})`
+  const platformInfo = `(${process?.platform || ''}; ${process?.arch || ''})`
 
   return `node.js/${nodeVersion} ${platformInfo}`
 }


### PR DESCRIPTION
### Summary
Fix issue with missing `process` object in non supported environments like `React Native`

### Completed Tasks
- [x] fix issue process object in an unknown enviornment
- [x] assert that the process object exists and contains the necessary properties

### Related Issue
[1006](https://github.com/commercetools/commercetools-sdk-typescript/issues/1006)