### PR TITLE
[Chore] Temporarily Skip Long Running Tests

### DIFF
--- a/packages/platform-sdk/test/integration-tests/order/order.test.ts
+++ b/packages/platform-sdk/test/integration-tests/order/order.test.ts
@@ -92,7 +92,7 @@ describe('testing order API calls', () => {
     order = _order
   })
 
-  it('should search an order', async () => {
+  it.skip('should search an order', async () => {
     let project = await ctpApiBuilder.get().execute()
 
     if (project.body.searchIndexing.orders.status === 'Deactivated') {


### PR DESCRIPTION
### Summary
Search indexing is taking too long to complete, skipping this tests until we find a workaround.

### Completed Tasks
- [x] skip test due to long running search indexing