### PR TITLE
fix(middleware): use optional chaining for generate function

### DIFF
--- a/.changeset/correlation-id-middleware.md
+++ b/.changeset/correlation-id-middleware.md
@@ -1,0 +1,7 @@
+---
+'@commercetools/sdk-client-v3': patch
+---
+
+**Bug Fix**
+
+Fixed a potential undefined error in the correlation ID middleware by adding optional chaining when checking for the custom generate function. This prevents the middleware from throwing an error when options are not provided.

--- a/packages/sdk-client-v3/src/middleware/create-correlation-id-middleware.ts
+++ b/packages/sdk-client-v3/src/middleware/create-correlation-id-middleware.ts
@@ -15,7 +15,7 @@ export default function createCorrelationIdMiddleware(
       headers: {
         ...request.headers,
         'X-Correlation-ID':
-          options.generate && typeof options.generate == 'function'
+          options?.generate && typeof options.generate == 'function'
             ? options.generate()
             : generate(),
       },


### PR DESCRIPTION
Found out we had some errors: TypeError: Cannot read properties of undefined (reading 'generate').

Applied a fix. Maybe for future improvements, add some more and strict typescript config. That will prevent these kind of issues to be on production.