### PR TITLE
[Feat][DEVX-619]: Add Custom `headersWithStringBody` to HttpMiddlewareOptions

### DIFF
--- a/.changeset/sharp-files-end.md
+++ b/.changeset/sharp-files-end.md
@@ -1,0 +1,8 @@
+---
+"@commercetools/ts-client": minor
+---
+
+[Feat][DEVX-619]: Add Custom `headersWithStringBody` to HttpMiddlewareOptions
+Sometimes we might want to `stringify` a request body before sending to server, 
+this functionality allows the user to add custom `header` entries that forces 
+the request body to be `stringified` before it's send over to the backend.

--- a/.changeset/sharp-files-end.md
+++ b/.changeset/sharp-files-end.md
@@ -1,8 +1,8 @@
 ---
-"@commercetools/ts-client": minor
+'@commercetools/ts-client': minor
 ---
 
-[Feat][DEVX-619]: Add Custom `headersWithStringBody` to HttpMiddlewareOptions
-Sometimes we might want to `stringify` a request body before sending to server, 
-this functionality allows the user to add custom `header` entries that forces 
-the request body to be `stringified` before it's send over to the backend.
+Add custom `stringBodyContentTypes` to `HttpMiddlewareOptions`
+Sometimes we might want to `stringify` a request body before sending it over to
+server, this functionality allows the user to add custom `header` entries that
+forces the request body to be `stringified` before it's sent over to the backend.

--- a/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
+++ b/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
@@ -149,7 +149,7 @@ export default function createHttpMiddleware(
     includeResponseHeaders = true,
     maskSensitiveHeaderData,
     httpClientOptions,
-    headersWithStringBody = [],
+    stringBodyContentTypes = [],
   } = options
 
   return (next: Next) => {
@@ -158,7 +158,7 @@ export default function createHttpMiddleware(
       const requestHeader: JsonObject<QueryParam> = { ...request.headers }
 
       // validate custom header
-      validateStringBodyHeaderOptions(headersWithStringBody)
+      validateStringBodyHeaderOptions(stringBodyContentTypes)
 
       // validate header
       if (
@@ -177,9 +177,10 @@ export default function createHttpMiddleware(
 
       // Ensure body is a string if content type is application/{json|graphql}
       const body: Record<string, any> | string | Uint8Array =
-        ([...constants.HEADERS_CONTENT_TYPES, ...headersWithStringBody].indexOf(
-          requestHeader['Content-Type'] as string
-        ) > -1 &&
+        ([
+          ...constants.HEADERS_CONTENT_TYPES,
+          ...stringBodyContentTypes,
+        ].indexOf(requestHeader['Content-Type'] as string) > -1 &&
           typeof request.body === 'string') ||
         isBuffer(request.body)
           ? request.body

--- a/packages/sdk-client-v3/src/types/types.d.ts
+++ b/packages/sdk-client-v3/src/types/types.d.ts
@@ -218,7 +218,7 @@ export type HttpMiddlewareOptions = {
   enableRetry?: boolean
   retryConfig?: RetryOptions
   httpClient?: Function
-  headersWithStringBody?: Array<string>
+  stringBodyContentTypes?: Array<string>
   httpClientOptions?: object // will be passed as a second argument to your httpClient function for configuration
   getAbortController?: () => AbortController
 }

--- a/packages/sdk-client-v3/src/types/types.d.ts
+++ b/packages/sdk-client-v3/src/types/types.d.ts
@@ -218,6 +218,7 @@ export type HttpMiddlewareOptions = {
   enableRetry?: boolean
   retryConfig?: RetryOptions
   httpClient?: Function
+  headersWithStringBody?: Array<string>
   httpClientOptions?: object // will be passed as a second argument to your httpClient function for configuration
   getAbortController?: () => AbortController
 }

--- a/packages/sdk-client-v3/src/utils/index.ts
+++ b/packages/sdk-client-v3/src/utils/index.ts
@@ -20,5 +20,6 @@ export { default as userAgent } from './userAgent'
 export {
     validate,
     // validateUserAgentOptions,
+    validateStringBodyHeaderOptions,
     validateClient, validateHttpClientOptions, validateRetryCodes
 } from './validate'

--- a/packages/sdk-client-v3/src/utils/validate.ts
+++ b/packages/sdk-client-v3/src/utils/validate.ts
@@ -84,3 +84,16 @@ export function validate(
       `The "${funcName}" Request object requires a valid method. See https://commercetools.github.io/nodejs/sdk/Glossary.html#clientrequest`
     )
 }
+
+/**
+ * @param option
+ */
+export function validateStringBodyHeaderOptions(
+  headersWithStringBody: string[]
+) {
+  if (!Array.isArray(headersWithStringBody)) {
+    throw new Error(
+      '`headersWithStringBody` option must be an array of strings'
+    )
+  }
+}

--- a/packages/sdk-client-v3/src/utils/validate.ts
+++ b/packages/sdk-client-v3/src/utils/validate.ts
@@ -89,11 +89,11 @@ export function validate(
  * @param option
  */
 export function validateStringBodyHeaderOptions(
-  headersWithStringBody: string[]
+  stringBodyContentTypes: string[]
 ) {
-  if (!Array.isArray(headersWithStringBody)) {
+  if (!Array.isArray(stringBodyContentTypes)) {
     throw new Error(
-      '`headersWithStringBody` option must be an array of strings'
+      '`stringBodyContentTypes` option must be an array of strings'
     )
   }
 }

--- a/packages/sdk-client-v3/tests/http.test/http-middleware.test.ts
+++ b/packages/sdk-client-v3/tests/http.test/http-middleware.test.ts
@@ -96,13 +96,13 @@ describe('Http Middleware.', () => {
   })
 
   // test('should throw if httpClient is provided but not a function.', async () => {
-  test('throw when a non-array option is passed as headersWithStringBody in the httpMiddlewareOptions', async () => {
+  test('throw when a non-array option is passed as stringBodyContentTypes in the httpMiddlewareOptions', async () => {
     const response = createTestResponse({})
 
     const httpMiddlewareOptions = {
       host: 'http://api-host.com',
       httpClient: jest.fn(() => response),
-      headersWithStringBody: null,
+      stringBodyContentTypes: null,
     }
 
     try {
@@ -113,7 +113,7 @@ describe('Http Middleware.', () => {
     } catch (err) {
       expect(err).toBeDefined()
       expect(err.message).toMatch(
-        '`headersWithStringBody` option must be an array of strings'
+        '`stringBodyContentTypes` option must be an array of strings'
       )
     }
   })
@@ -514,7 +514,7 @@ describe('Http Middleware.', () => {
     const httpMiddlewareOptions: HttpMiddlewareOptions = {
       host: 'http://api-host.com',
       httpClient: jest.fn(() => response),
-      headersWithStringBody: ['foo'],
+      stringBodyContentTypes: ['foo'],
     }
 
     const next = (req: MiddlewareRequest) => {
@@ -553,7 +553,7 @@ describe('Http Middleware.', () => {
 
     const httpMiddlewareOptions: HttpMiddlewareOptions = {
       host: 'http://api-host.com',
-      headersWithStringBody: ['bar'],
+      stringBodyContentTypes: ['bar'],
       httpClient: jest
         .fn()
         .mockImplementation((url: string, fetchOptions: RequestInit) => {


### PR DESCRIPTION
### Summary
Sometimes we might want to stringify a request body before sending to server, this will allow the user to add custom header entries that force the request body to be stringified before sending it over to the backend.

### Completed Tasks
- [x] add httpMiddleware option to stringify request body on demand
- [x] add the corresponding type definition for the new option
- [x] add validation to ensure provided option is correct
- [x] add unit tests to validate new functionality and also no regression

### Related Issue
This should now solve [this](https://github.com/commercetools/commercetools-sdk-typescript/issues/1039) open issue