### PR TITLE
[Chore] Avoid Manually Setting Request Content Length

### DIFF
--- a/.changeset/flat-cows-double.md
+++ b/.changeset/flat-cows-double.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/ts-client': patch
+---
+
+remove content-length headers and allow underlying client to calculate conent length

--- a/packages/sdk-client-v3/src/middleware/auth-middleware/auth-request-executor.ts
+++ b/packages/sdk-client-v3/src/middleware/auth-middleware/auth-request-executor.ts
@@ -68,7 +68,6 @@ export async function executeRequest(options: ExecuteRequestOptions) {
         ...request.headers,
         Authorization: `Basic ${basicAuth}`,
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': byteLength(body),
       },
       httpClient,
       httpClientOptions,

--- a/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
+++ b/packages/sdk-client-v3/src/middleware/create-http-middleware.ts
@@ -186,10 +186,6 @@ export default function createHttpMiddleware(
           ? request.body
           : JSON.stringify(request.body || undefined)
 
-      if (body && (typeof body === 'string' || isBuffer(body))) {
-        requestHeader['Content-Length'] = byteLength(body)
-      }
-
       const clientOptions: HttpClientOptions = {
         enableRetry,
         retryConfig,


### PR DESCRIPTION
### Summary
Avoid setting content-length manually

### Completed Tasks
- [x] remove manually calculated content-length in the SDK and allow underlying client to carryout the computation

### Related Issue
#1262