### PR TITLE
Update docs links in readme files

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -40,7 +40,7 @@ offered by the SDK including security and vulnerability fixes.
 
 ## Documentation
 
-Ensure to read the [documentation](https://docs.commercetools.com/sdk/javascript-sdk) carefully in order
+Ensure to read the [documentation](https://docs.commercetools.com/dev-tooling/typescript-sdk) carefully in order
 to correctly and properly implement and/or integrate the SDK.
 
 ## Issues
@@ -107,7 +107,7 @@ const client = new ClientBuilder()
 
 Middleware is used to add functionality to the request object in the TypeScript SDK. You can add middleware when creating the TypeScript SDK client. Multiple middleware can be added using a chain of middleware builder methods.
 
-Please check [here](https://docs.commercetools.com/sdk/ts-sdk-middleware-v3) for more details.
+Please check [here](https://docs.commercetools.com/dev-tooling/ts-sdk-middleware) for more details.
 
 ## How to reuse client (connection)
 
@@ -221,7 +221,7 @@ In the commercetools JS/TS SDK the connection tears down automatically after eac
 
 The commercetools JS/TS client can be customized in a variety of ways, this can be achieved by passing in middleware options that can take different parameter values.
 Refer to the [Client Initialization](#client-initialization) section for details on how to create the client.
-To see how to configure the available middleware options and their configurations, please check [the official documentation](https://docs.commercetools.com/sdk/ts-sdk-middleware-v3).
+To see how to configure the available middleware options and their configurations, please check [the official documentation](https://docs.commercetools.com/dev-tooling/ts-sdk-middleware).
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains several SDK packages generated from the commercetools C
 
 ## Documentation
 
-The documentation and usage example for the TypeScript SDK can be found [here](https://docs.commercetools.com/sdk/javascript-sdk)
+Official documentation, a getting started guide, and usage examples for the TypeScript SDK can be found [here](https://docs.commercetools.com/dev-tooling/typescript-sdk)
 
 The complete Type Documentation, function and class specifications can also be found [here](https://commercetools.github.io/commercetools-sdk-typescript/)
 
@@ -33,7 +33,7 @@ If you have any urgent issues regarding this repository please create a support 
 
 ## Best Practices
 
-We have a doc with a currated list of best practices designed to assist developers on how best to use and develop applications using the JavaScript/TypeScript SDK. The best practices doc can be found [here](BEST_PRACTICES.md).
+We have a doc with a curated list of best practices designed to assist developers on how best to use and develop applications using the TypeScript SDK. The best practices doc can be found [here](https://docs.commercetools.com/dev-tooling/ts-sdk-best-practices).
 
 ## Packages
 
@@ -44,6 +44,7 @@ We have a doc with a currated list of best practices designed to assist develope
 | [`platform-sdk`](/packages/platform-sdk)   | [![platform-sdk Version][platform-sdk-icon]][platform-sdk-version]    |
 | [`importapi-sdk`](/packages/importapi-sdk) | [![importapi-sdk Version][importapi-sdk-icon]][importapi-sdk-version] |
 | [`history-sdk`](/packages/history-sdk)     | [![history-sdk Version][history-sdk-icon]][history-sdk-version]       |
+| [`checkout-sdk`](/packages/checkout-sdk)     | [![checkout-sdk Version][checkout-sdk-icon]][checkout-sdk-version]       |
 | [`ts-client`](/packages/sdk-client-v3)     | [![client-sdk Version][sdk-client-icon]][sdk-client-version]          |
 
 [platform-sdk-version]: https://www.npmjs.com/package/@commercetools/platform-sdk
@@ -52,5 +53,7 @@ We have a doc with a currated list of best practices designed to assist develope
 [importapi-sdk-icon]: https://img.shields.io/npm/v/@commercetools/importapi-sdk.svg?style=flat-square
 [history-sdk-version]: https://www.npmjs.com/package/@commercetools/history-sdk
 [history-sdk-icon]: https://img.shields.io/npm/v/@commercetools/history-sdk.svg?style=flat-square
+[checkout-sdk-version]: https://www.npmjs.com/package/@commercetools/checkout-sdk
+[checkout-sdk-icon]: https://img.shields.io/npm/v/@commercetools/checkout-sdk.svg?style=flat-square
 [sdk-client-version]: https://www.npmjs.com/package/@commercetools/ts-client
 [sdk-client-icon]: https://img.shields.io/npm/v/@commercetools/ts-client.svg?style=flat-square

--- a/examples/datadog-express-apm/container-agent/README.md
+++ b/examples/datadog-express-apm/container-agent/README.md
@@ -4,10 +4,10 @@ Example to show how the Datadog APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/sdk/js-sdk-getting-started).
+- A Composable Commerce Project with a configured [API Client]https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
-- For Datadog setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/sdk/observability/datadog#typescript-sdk) to properly install and set up the Datadog agent.
+- For Datadog setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/datadog#typescript-sdk) to properly install and set up the Datadog agent.
   - Make sure that `Node js` has been installed as [Integration](https://docs.datadoghq.com/integrations/) to run this Demo application.
 
 ## Installation

--- a/examples/datadog-express-apm/host-agent/README.md
+++ b/examples/datadog-express-apm/host-agent/README.md
@@ -4,10 +4,10 @@ Example to show how the Datadog APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/sdk/js-sdk-getting-started).
+- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
-- For Datadog setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/sdk/observability/datadog#typescript-sdk) to properly install and set up the Datadog agent.
+- For Datadog setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/datadog#typescript-sdk) to properly install and set up the Datadog agent.
   - Make sure that `Node js` has been installed as [Integration](https://docs.datadoghq.com/integrations/) to run this Demo application.
 
 ## Installation

--- a/examples/dynatrace-express-apm/README.md
+++ b/examples/dynatrace-express-apm/README.md
@@ -4,10 +4,10 @@ Example to show how the Dynatrace APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/sdk/js-sdk-getting-started).
+- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
-- For Dynatrace setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/sdk/observability/dynatrace#typescript-sdk) to properly install and set up the Dynatrace agent.
+- For Dynatrace setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/dynatrace#typescript-sdk) to properly install and set up the Dynatrace agent.
 
 ## Installation
 
@@ -27,4 +27,4 @@ Example to show how the Dynatrace APM can be used in the TypeScript SDK.
 - GET https://localhost:9000/products
 ```
 
-Please check the [official documentation](https://docs.commercetools.com/sdk/observability/dynatrace#include-the-monitoring-package-in-your-sdk) for more details.
+Please check the [official documentation](https://docs.commercetools.com/dev-tooling/observability/dynatrace#typescript-sdk) for more details.

--- a/examples/me/README.md
+++ b/examples/me/README.md
@@ -4,7 +4,7 @@ Example to show how the ME endpoints can be used with the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/tutorials/getting-started#creating-an-api-client).
+- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/initial-setup#creating-an-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 

--- a/examples/newrelic-express-apm/README.md
+++ b/examples/newrelic-express-apm/README.md
@@ -4,10 +4,10 @@ Example to show how the Newrelic APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/sdk/js-sdk-getting-started).
+- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
-- For Newrelic setup, follow the instructions stated on our [official documentation website](https://docs.commercetools.com/sdk/observability/newrelic#typescript-sdk) to properly install and set up the newrelic agent.
+- For Newrelic setup, follow the instructions stated on our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/newrelic#typescript-sdk) to properly install and set up the newrelic agent.
 
 ## Installation
 


### PR DESCRIPTION
This PR updates links in readme files.

I also noticed that the `checkout-sdk` SDK package wasn't highlighted at the bottom of the main readme file.