### PR TITLE
Remove Composable Commerce branding

### DIFF
--- a/.changeset/khaki-colts-hunt.md
+++ b/.changeset/khaki-colts-hunt.md
@@ -1,0 +1,11 @@
+---
+"@commercetools/checkout-sdk": patch
+"@commercetools/history-sdk": patch
+"@commercetools/importapi-sdk": patch
+"@commercetools/platform-sdk": patch
+"@commercetools/ts-client": patch
+"@commercetools/sdk-client-v2": patch
+"@commercetools/ts-sdk-apm": patch
+---
+
+Remove Composable Commerce branding

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -326,6 +326,6 @@ See this [test](https://github.com/commercetools/commercetools-sdk-typescript/bl
 
 ## How to read or write fields not included in the SDK
 
-In some rare occasions some object properties can be returned by Composable Commerce that are not part of the SDK response specification. E.g the error response object has some entries which are not specified as part of the TS SDK error types. In this situation, the existing type can be extended with the missing property or ignored entirely. [See this issue](https://github.com/commercetools/commercetools-sdk-typescript/issues/247#issuecomment-1103705075) for more explanation on this.
+In some rare occasions some object properties can be returned that are not part of the SDK response specification. E.g the error response object has some entries which are not specified as part of the TS SDK error types. In this situation, the existing type can be extended with the missing property or ignored entirely. [See this issue](https://github.com/commercetools/commercetools-sdk-typescript/issues/247#issuecomment-1103705075) for more explanation on this.
 
 It is also noteworthy that this omission can be as a result of the entries not being part of the [official docs](https://docs.commercetools.com/api/errors) to get a clear type specification for these entries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please take a moment to review this document in order to make the contribution p
 
 ## Core ideas
 
-The repository primarily contains SDK packages in TypeScript generated from the Composable Commerce API reference.
+The repository primarily contains SDK packages in TypeScript generated from the commercetools API reference.
 
 ## Repository structure
 
@@ -68,7 +68,7 @@ Some useful commands to work with the repository:
 
 ## Adding changesets
 
-Composable Commerce Typescript SDK uses [changesets](https://github.com/atlassian/changesets) to do versioning and creating changelogs.
+The commercetools Typescript SDK uses [changesets](https://github.com/atlassian/changesets) to do versioning and creating changelogs.
 
 As a contributor you need to add a changeset by running `yarn changeset`.
 The command will prompt to select the packages that should be bumped, their associated semver bump types and some markdown which will be inserted into the changelogs.
@@ -77,7 +77,7 @@ When opening a Pull Request, a `changeset-bot` checks that the Pull Request cont
 
 ## Releasing packages
 
-Composable Commerce Typescript SDK uses [changesets](https://github.com/atlassian/changesets) to do versioning and publishing a release.
+The commercetools Typescript SDK uses [changesets](https://github.com/atlassian/changesets) to do versioning and publishing a release.
 
 A [Changesets release GitHub Action](https://github.com/changesets/action) opens a `Version Packages` Pull Request whenever there are some changesets that have not been released yet.
 

--- a/GenerateSDK.md
+++ b/GenerateSDK.md
@@ -1,6 +1,6 @@
-# Composable Commerce TypeScript SDKs Generation
+# commercetools TypeScript SDKs Generation
 
-This repo contains Composable Commerce SDKs and this is a guide on how to generate the Typescript SDK.
+This repo contains commercetools SDKs and this is a guide on how to generate the Typescript SDK.
 
 ## Requirements
 
@@ -20,13 +20,13 @@ run `yarn generate` to generate the sdks. (make sure the environment variables a
 
 | Variable name |                                                    Description                                                     |
 | ------------- | :----------------------------------------------------------------------------------------------------------------: |
-| API_RAML_FILE | The path to Composable Commerce [HTTP API reference](https://github.com/commercetools/commercetools-api-reference) |
+| API_RAML_FILE | The path to commercetools [HTTP API reference](https://github.com/commercetools/commercetools-api-reference) |
 
 ## Test environnement variables
 
 | Variable name     |                  Description                   |
 | ----------------- | :--------------------------------------------: |
-| CTP_PROJECT_KEY   |        Composable Commerce Project key         |
+| CTP_PROJECT_KEY   |        commercetools Project key         |
 | CTP_CLIENT_ID     |                 the client id                  |
 | CTP_CLIENT_SECRET |               the client secret                |
 | CTP_API_URL       | the API url (contains infos about the region)  |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<h2 align="center">Composable Commerce TypeScript SDKs 💅</h2>
+<h2 align="center">commercetools TypeScript SDKs 💅</h2>
 <p align="center">
-  <i>✨ Monorepository with generated TypeScript SDKs for the Composable Commerce APIs 🛠</i>
+  <i>✨ Monorepository with generated TypeScript SDKs for commercetools APIs 🛠</i>
 </p>
 <p align="center">
   <a href="https://circleci.com/gh/commercetools/commercetools-sdk-typescript">
@@ -17,7 +17,7 @@
 
 ## Introduction
 
-This repository contains several SDK packages generated from the commercetools Composable Commerce API reference.
+This repository contains several SDK packages generated from the commercetools API reference.
 
 ## Documentation
 

--- a/examples/datadog-express-apm/container-agent/README.md
+++ b/examples/datadog-express-apm/container-agent/README.md
@@ -4,7 +4,7 @@ Example to show how the Datadog APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client]https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Project with a configured [API Client]https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 - For Datadog setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/datadog#typescript-sdk) to properly install and set up the Datadog agent.

--- a/examples/datadog-express-apm/host-agent/README.md
+++ b/examples/datadog-express-apm/host-agent/README.md
@@ -4,7 +4,7 @@ Example to show how the Datadog APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 - For Datadog setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/datadog#typescript-sdk) to properly install and set up the Datadog agent.

--- a/examples/dynatrace-express-apm/README.md
+++ b/examples/dynatrace-express-apm/README.md
@@ -4,7 +4,7 @@ Example to show how the Dynatrace APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 - For Dynatrace setup, follow the instructions stated in our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/dynatrace#typescript-sdk) to properly install and set up the Dynatrace agent.

--- a/examples/me/README.md
+++ b/examples/me/README.md
@@ -4,7 +4,7 @@ Example to show how the ME endpoints can be used with the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/initial-setup#creating-an-api-client).
+- A commercetools Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/initial-setup#creating-an-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 
@@ -31,7 +31,7 @@ CTP_API_URL={hostUrl}
 DEFAULT_CURRENCY=EUR
 ```
 
-6. Replace `{clientID}`, `{projectKey}`, `{authUrl}`, `{hostUrl}` and `{clientSecret}` with the respective values from your API Client. The `DEFAULT_CURRENCY` can be changed based on your Composable Commerce Project settings.
+6. Replace `{clientID}`, `{projectKey}`, `{authUrl}`, `{hostUrl}` and `{clientSecret}` with the respective values from your API Client. The `DEFAULT_CURRENCY` can be changed based on your commercetools Project settings.
 
 ## Using the ME Endpoint Checkout App
 

--- a/examples/me/server/src/app.ts
+++ b/examples/me/server/src/app.ts
@@ -38,7 +38,7 @@ app.use('/', routes)
 app.get('/home', async function (_, res) {
   res.status(200).json({
     status: 'success',
-    message: 'Welcome to Composable Commerce ME endpoint demo app',
+    message: 'Welcome to commercetools ME endpoint demo app',
   })
 })
 app.use('*', async (_, res: Response) => {

--- a/examples/newrelic-express-apm/README.md
+++ b/examples/newrelic-express-apm/README.md
@@ -4,7 +4,7 @@ Example to show how the Newrelic APM can be used in the TypeScript SDK.
 
 ## Requirements
 
-- A Composable Commerce Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
+- A commercetools Project with a configured [API Client](https://docs.commercetools.com/api/getting-started/create-api-client).
 - Your Project must have existing Products containing Variants, and at least one Customer.
 - If your Project is currently empty, you can install the [SUNRISE sample data](https://github.com/commercetools/commercetools-sunrise-data).
 - For Newrelic setup, follow the instructions stated on our [official documentation website](https://docs.commercetools.com/dev-tooling/observability/newrelic#typescript-sdk) to properly install and set up the newrelic agent.

--- a/packages/checkout-sdk/README.md
+++ b/packages/checkout-sdk/README.md
@@ -1,4 +1,4 @@
-# Typescript SDK for Composable Commerce Checkout APIs.
+# Typescript SDK for the commercetools Checkout API.
 
 ## Usage examples
 

--- a/packages/checkout-sdk/package.json
+++ b/packages/checkout-sdk/package.json
@@ -8,10 +8,9 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "Typescript SDK for Composable Commerce Checkout API",
+  "description": "Typescript SDK for the commercetools Checkout API",
   "keywords": [
     "commercetools",
-    "composable commerce",
     "typescript",
     "sdk",
     "checkout"

--- a/packages/history-sdk/README.md
+++ b/packages/history-sdk/README.md
@@ -1,4 +1,4 @@
-# Typescript SDK for Composable Commerce Audit log (history) APIs.
+# Typescript SDK for commercetools Audit log (history) APIs.
 
 ## Usage examples
 

--- a/packages/history-sdk/package.json
+++ b/packages/history-sdk/package.json
@@ -8,10 +8,9 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "Typescript SDK for Composable Commerce Audit Log features",
+  "description": "Typescript SDK for commercetools Audit Log features",
   "keywords": [
     "commercetools",
-    "composable commerce",
     "typescript",
     "sdk",
     "history"

--- a/packages/importapi-sdk/README.md
+++ b/packages/importapi-sdk/README.md
@@ -1,4 +1,4 @@
-# TypeScript SDK for commercetools Composable Commerce Import API
+# TypeScript SDK for commercetools Import API
 
 ## Usage examples
 

--- a/packages/importapi-sdk/package.json
+++ b/packages/importapi-sdk/package.json
@@ -8,10 +8,9 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "TypeScript SDK for Composable Commerce Import API features",
+  "description": "TypeScript SDK for commercetools Import API features",
   "keywords": [
     "commercetools",
-    "composable commerce",
     "typescript",
     "sdk",
     "import"

--- a/packages/platform-sdk/README.md
+++ b/packages/platform-sdk/README.md
@@ -1,4 +1,4 @@
-# TypeScript SDK for commercetools Composable Commerce HTTP API
+# TypeScript SDK for commercetools HTTP API
 
 ## Usage examples
 

--- a/packages/platform-sdk/package.json
+++ b/packages/platform-sdk/package.json
@@ -8,8 +8,8 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "TypeScript definitions and SDK for commercetools Composable Commerce",
-  "keywords": ["commercetools", "composable commerce", "typescript", "sdk"],
+  "description": "TypeScript definitions and SDK for commercetools HTTP API",
+  "keywords": ["commercetools", "typescript", "sdk"],
   "homepage": "https://github.com/commercetools/commercetools-sdk-typescript",
   "bugs": "https://github.com/commercetools/commercetools-sdk-typescript/issues",
   "repository": {

--- a/packages/sdk-client-v3/README.md
+++ b/packages/sdk-client-v3/README.md
@@ -1,4 +1,4 @@
-# Commercetools Composable Commerce (Improved) TypeScript SDK client
+# commercetools (Improved) TypeScript SDK client
 
 This is the new and improved Typescript SDK client.
 
@@ -85,7 +85,7 @@ const client: Client = new ClientBuilder()
 
 const apiRoot = createApiBuilderFromCtpClient(client)
 
-// calling the Composable Commerce `api` functions
+// calling the commercetools `api` functions
 // get project details
 apiRoot
   .withProjectKey({ projectKey })

--- a/packages/sdk-client-v3/package.json
+++ b/packages/sdk-client-v3/package.json
@@ -4,10 +4,9 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "commercetools Composable Commerce TypeScript SDK client.",
+  "description": "commercetools TypeScript SDK client.",
   "keywords": [
     "commercetools",
-    "composable commerce",
     "sdk",
     "typescript",
     "client",

--- a/packages/sdk-client/README.md
+++ b/packages/sdk-client/README.md
@@ -1,4 +1,4 @@
-# Commercetools Composable Commerce TypeScript SDK client
+# commercetools TypeScript SDK client
 
 ## Usage examples
 
@@ -76,7 +76,7 @@ const client = new ClientBuilder()
 
 const apiRoot = createApiBuilderFromCtpClient(client)
 
-// calling the Composable Commerce functions
+// calling commercetools functions
 // get project details
 apiRoot
   .withProjectKey({

--- a/packages/sdk-client/package.json
+++ b/packages/sdk-client/package.json
@@ -4,10 +4,9 @@
   "engines": {
     "node": ">=22"
   },
-  "description": "commercetools Composable Commerce TypeScript SDK client.",
+  "description": "commercetools TypeScript SDK client.",
   "keywords": [
     "commercetools",
-    "composable commerce",
     "sdk",
     "typescript",
     "client",

--- a/packages/ts-sdk-apm/package.json
+++ b/packages/ts-sdk-apm/package.json
@@ -23,7 +23,6 @@
   },
   "keywords": [
     "commercetools",
-    "composable commerce",
     "typescript",
     "sdk",
     "apm",


### PR DESCRIPTION
This PR removes the "Composable Commerce" branding from docs, descriptions, keywords, and comments in non-autogenerated files.