### PR TITLE
chore(changeset): add changeset to release a new SDK version

### DIFF
--- a/.changeset/quiet-pianos-release.md
+++ b/.changeset/quiet-pianos-release.md
@@ -1,0 +1,8 @@
+---
+'@commercetools/checkout-sdk': patch
+'@commercetools/history-sdk': patch
+'@commercetools/importapi-sdk': patch
+'@commercetools/platform-sdk': patch
+---
+
+Release a new version of the SDKs, including the latest generated documentation updates


### PR DESCRIPTION
## Summary

Adds a changeset so the pending SDK changes get released.

The latest codegen run ([#1425](https://github.com/commercetools/commercetools-sdk-typescript/pull/1425)) landed without a changeset — it updated doc comments across `history-sdk`, `importapi-sdk`, and `platform-sdk`, plus `package.json` metadata for `checkout-sdk`. This changeset covers those as a `patch`.

## Resulting versions

Three changesets were already pending on `master`, so the released versions are driven mostly by those. This PR adds a changelog entry without changing any resulting version number:

| Package | Current | Released as | Driven by |
|---|---|---|---|
| `@commercetools/platform-sdk` | 9.2.0 | 9.3.0 (minor) | `changes_api.md` |
| `@commercetools/history-sdk` | 6.0.0 | 6.1.0 (minor) | `changes_history.md` |
| `@commercetools/checkout-sdk` | 2.0.0 | 2.0.1 (patch) | `khaki-colts-hunt.md` |
| `@commercetools/importapi-sdk` | 7.1.0 | 7.1.1 (patch) | `khaki-colts-hunt.md` |
| `@commercetools/ts-client` | 5.0.0 | 5.0.1 (patch) | `khaki-colts-hunt.md` |
| `@commercetools/sdk-client-v2` | 4.0.0 | 4.0.1 (patch) | `khaki-colts-hunt.md` |
| `@commercetools/ts-sdk-apm` | 5.0.0 | 5.0.1 (patch) | `khaki-colts-hunt.md` |

Merging this triggers the `changesets` workflow to open/update the `changeset-release/master` version PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)