### PR TITLE
fix(ci): unblock release build after setup-node v7 bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,16 +52,19 @@ jobs:
       # Configure npm for OIDC authentication with trusted publishing
       # This must be done after CI setup to ensure npm is properly configured
 
-      # setup-node@v4 with registry-url automatically configures OIDC when id-token: write is set
+      # setup-node with registry-url automatically configures OIDC when id-token: write is set
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Building packages
-        run: yarn build
-
+      # Must run before any yarn command. setup-node writes an .npmrc containing
+      # `_authToken=${NODE_AUTH_TOKEN}` and points NPM_CONFIG_USERCONFIG at it. Since
+      # setup-node v7 no longer exports a dummy NODE_AUTH_TOKEN (actions/setup-node#1558)
+      # and we publish via OIDC rather than a token, that variable is undefined and
+      # yarn v1 hard-fails with "Failed to replace env in config: ${NODE_AUTH_TOKEN}".
+      # Dropping the auth line resolves that and leaves OIDC as the only auth mechanism.
       - name: Verify npm OIDC configuration
         run: |
           # Verify registry is set correctly
@@ -70,6 +73,9 @@ jobs:
           npm config delete //registry.npmjs.org/:_authToken || true
           # Verify npm can access the registry (this will use OIDC if configured)
           echo "npm OIDC authentication configured via setup-node action"
+
+      - name: Building packages
+        run: yarn build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Problem

Every `Release` workflow run since [#1411](https://github.com/commercetools/commercetools-sdk-typescript/pull/1411) (`actions/setup-node` v6 → v7) has failed on the `Building packages` step:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
    at envReplace (/usr/local/lib/node_modules/yarn/lib/cli.js:95448:16)
    at NpmRegistry.normalizeConfig (/usr/local/lib/node_modules/yarn/lib/cli.js:31940:69)
```

No release has been published since then. Last green run was commit `4ca4d03d`; `f953eb5d` (the v7 bump) is the very next commit on `master`.

## Cause

1. `Setup Node.js for npm publishing` uses `setup-node` with `registry-url`, which writes a temp `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and exports `NPM_CONFIG_USERCONFIG` pointing at it — so every later `yarn`/`npm` call in the job reads that file.
2. Through v6, setup-node *also* exported a dummy `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` when no token was set. v7 removed this — [actions/setup-node#1558](https://github.com/actions/setup-node/pull/1558), listed under "Bug fixes" in the [v7.0.0 notes](https://github.com/actions/setup-node/releases/tag/v7.0.0).
3. We publish via OIDC trusted publishing, so nothing sets `NODE_AUTH_TOKEN` (`grep -rn NODE_AUTH_TOKEN .github/` → no matches). The variable is now genuinely undefined.
4. Yarn v1 throws on an unresolvable `${...}` in npmrc, so `yarn build` dies immediately.

## Fix

Move the existing `Verify npm OIDC configuration` step ahead of `Building packages`. It already runs `npm config delete //registry.npmjs.org/:_authToken`, which strips the unresolvable reference from the npmrc — yarn never sees it, and OIDC remains the only auth mechanism.

Also corrected a stale `setup-node@v4` comment.

## Verification

Reproduced and validated locally against a replica of setup-node's npmrc (npm 11.11.0, yarn 1.22.22):

- `NODE_AUTH_TOKEN` unset → yarn fails with the exact CI error
- npm tolerates the unset variable (no throw, exit 0), so the `delete` step runs fine even before the reference is stripped
- after `npm config delete`, the auth line is gone and yarn runs fine against the same npmrc

## Alternatives considered

- **`NODE_AUTH_TOKEN: ""` at job level** — satisfies yarn, but injects an empty `_authToken` into the npmrc, which is exactly the "non-functional token value" upstream removed the dummy to avoid.
- **`NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`** — would quietly revert the OIDC migration back to token auth.

## Note for reviewers

This unblocks the build, but the OIDC publish path itself has never executed successfully in this workflow, so the npmjs trusted-publisher configuration is unverified beyond this step. If `Create Release Pull Request or Publish to npm` fails after this merges, that's a separate issue.

There is also a pending changeset on `master` ([#1426](https://github.com/commercetools/commercetools-sdk-typescript/pull/1426)), so merging this should trigger a real version PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)