### PR TITLE
test(sdk-client-v3): deterministically cover the executor timeout path

### DIFF
--- a/packages/sdk-client-v3/tests/utils.test/executor.test.ts
+++ b/packages/sdk-client-v3/tests/utils.test/executor.test.ts
@@ -126,4 +126,53 @@ describe('executor', () => {
       )
     })
   })
+
+  describe('request timeout', () => {
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    test('aborts the request and reinitializes the abort controller once the timeout elapses', async () => {
+      jest.useFakeTimers()
+
+      const controllers: Array<AbortController> = []
+      const getAbortController = jest.fn(() => {
+        const controller = new AbortController()
+        controllers.push(controller)
+        return controller
+      })
+
+      // Hold the request open so the timeout is guaranteed to fire while it is
+      // still in flight, rather than racing a response that resolves instantly.
+      let resolveRequest!: (response: typeof mockResponse) => void
+      const httpClient = jest.fn(
+        () =>
+          new Promise<typeof mockResponse>((resolve) => {
+            resolveRequest = resolve
+          })
+      )
+
+      const pending = executor(
+        createExecutorConfig({ httpClient, getAbortController, timeout: 10 })
+      )
+
+      // Let the executor reach `execute()`; by then the timer has been armed.
+      for (let i = 0; i < 10 && httpClient.mock.calls.length === 0; i++) {
+        await Promise.resolve()
+      }
+      expect(httpClient).toHaveBeenCalledTimes(1)
+      expect(controllers).toHaveLength(1)
+
+      await jest.advanceTimersByTimeAsync(10)
+
+      expect(controllers[0].signal.aborted).toBe(true)
+      expect(controllers).toHaveLength(2)
+      expect(controllers[1].signal.aborted).toBe(false)
+
+      resolveRequest(mockResponse)
+      await expect(pending).resolves.toEqual(
+        expect.objectContaining({ data: { ok: true }, statusCode: 200 })
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Problem

`codecov/project` fails intermittently on PRs that change no source at all. It failed on #1427 (a workflow-YAML-only change) reporting `97.54% (-0.15%)`, while `codecov/patch` correctly reported "coverage not affected".

The cause is a nondeterministically covered block in `packages/sdk-client-v3/src/utils/executor.ts`:

```ts
timer = setTimeout(() => {
  abortController.abort()                        // line 88
  abortController = initializeAbortController()  // line 89
}, timeout)
```

Those two lines only execute if the timeout actually elapses while the request is in flight. The tests that exercise this path — e.g. `http-middleware.test.ts` "should throw if the set timeout value elapses" — set `timeout: 10` against a `jest.fn()` httpClient that resolves immediately, using **real** timers. Whether the callback wins that race depends on runner timing.

## Evidence

Comparing the two Codecov reports for #1427, which changed only `.github/workflows/release.yml`:

| Commit | Coverage | Lines | Hits | Misses |
|---|---|---|---|---|
| `4437269` (master, PR base) | 97.69% | 1345 | 1314 | 27 |
| `b9f5734f` (PR head) | 97.54% | 1345 | 1312 | 29 |

Identical total lines, exactly 2 lines flipped, and of all 88 files in the report the **only** one differing is `utils/executor.ts` (`hits 78→76`, `misses 1→3`). Line-level data confirms lines 88 and 89.

Because there is no `codecov.yml` in the repo, the default `project` threshold is 0%, so any decrease fails. Master itself oscillates between the two values, which is why this hits some PRs and not others:

| PR | codecov/project |
|---|---|
| #1426 | success — 97.69% (+0.14%) |
| #1424 | success — 97.54% (+0.00%) |
| #1416 | success — 97.69% (+0.14%) |
| #1413 | **failure** — 97.54% (-0.15%) |
| #1404 | **failure** — 97.54% (-0.15%) |
| #1427 | **failure** — 97.54% (-0.15%) |

## Fix

Add a test to `tests/utils.test/executor.test.ts` that uses fake timers and keeps the request pending, so the timeout is guaranteed to fire while it is in flight:

- holds `httpClient` open with an externally-resolved promise
- waits until `httpClient` has been called, which means the timer is armed
- `await jest.advanceTimersByTimeAsync(10)` to fire the callback
- asserts the first `AbortController` was aborted, that a second one was created, and that the request still resolves normally afterwards

`jest.useRealTimers()` in `afterEach` keeps the fake timers scoped to this block.

This covers the branch on every run rather than by luck, so project coverage settles deterministically at 97.69% and small real regressions remain detectable at the default 0% threshold.

## Verification

- `npx jest packages/sdk-client-v3/tests/utils.test/executor.test.ts` — 5 passed
- Full package suite: **22 suites / 225 tests passed**
- Instrumented coverage for `executor.ts` from this test file alone, over **10 consecutive runs**: lines 88 and 89 hit every time (previously a coin flip)
- `yarn typecheck` clean, `prettier --check` clean

## Note for reviewers

#1427 (the release-workflow fix) should go green once this lands and it is rebased. That PR is currently blocked only by this flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
