### PR TITLE
[Feat][DEVX-851] Make Platform SDK Use Same Client Host URL

### DIFF
--- a/.changeset/early-cobras-call.md
+++ b/.changeset/early-cobras-call.md
@@ -1,0 +1,6 @@
+---
+'@commercetools/ts-client': patch
+'@commercetools/platform-sdk': patch
+---
+
+Make platform SDK use configured client host url

--- a/packages/platform-sdk/src/ctp/ctp-client.ts
+++ b/packages/platform-sdk/src/ctp/ctp-client.ts
@@ -6,6 +6,6 @@ export function createApiBuilderFromCtpClient(
 ): ApiRoot {
   return new ApiRoot({
     executeRequest: ctpClient.execute,
-    baseUri: baseUri,
+    baseUri: ctpClient.baseUri ?? baseUri,
   })
 }

--- a/packages/sdk-client-v3/src/client/builder.ts
+++ b/packages/sdk-client-v3/src/client/builder.ts
@@ -41,6 +41,7 @@ const {
 } = middleware
 
 export default class ClientBuilder {
+  private baseUri: string | undefined
   private projectKey: string | undefined
 
   private authMiddleware: Nullable<Middleware>
@@ -190,6 +191,7 @@ export default class ClientBuilder {
   }
 
   public withHttpMiddleware(options: HttpMiddlewareOptions): ClientBuilder {
+    this.baseUri = options.host || constants.CTP_API_URL
     this.httpMiddleware = createHttpMiddleware({
       host: options.host || constants.CTP_API_URL,
       httpClient: options.httpClient || fetch,
@@ -287,6 +289,6 @@ export default class ClientBuilder {
     if (this.httpMiddleware) middlewares.push(this.httpMiddleware)
     if (this.afterMiddleware) middlewares.push(this.afterMiddleware)
 
-    return createClient({ middlewares })
+    return createClient({ middlewares, baseUri: this.baseUri })
   }
 }

--- a/packages/sdk-client-v3/src/client/client.ts
+++ b/packages/sdk-client-v3/src/client/client.ts
@@ -130,9 +130,12 @@ export function process<T extends object = any>(
   })
 }
 
-export default function createClient(middlewares: ClientOptions): Client {
-  _options = middlewares
-  validateClient(middlewares)
+export default function createClient({
+  middlewares,
+  baseUri,
+}: ClientOptions): Client {
+  _options = { middlewares, baseUri }
+  validateClient({ middlewares })
 
   let _maskSensitiveHeaderData = true
 
@@ -161,7 +164,7 @@ export default function createClient(middlewares: ClientOptions): Client {
     },
   }
 
-  const dispatch = compose(middlewares)(resolver.resolve as any)
+  const dispatch = compose({ middlewares })(resolver.resolve as any)
   return {
     process,
     execute(request: ClientRequest): Promise<ClientResult> {
@@ -181,5 +184,6 @@ export default function createClient(middlewares: ClientOptions): Client {
         }
       })
     },
+    baseUri,
   }
 }

--- a/packages/sdk-client-v3/src/types/types.d.ts
+++ b/packages/sdk-client-v3/src/types/types.d.ts
@@ -85,7 +85,7 @@ export type ClientResponse<T = any> = {
 }
 
 export type ClientResult<T extends object = any> = ClientResponse<T>
-export type ClientOptions = { middlewares: Array<Middleware> }
+export type ClientOptions = { middlewares: Array<Middleware>, baseUri?: string }
 
 export type Credentials = {
   clientId: string
@@ -324,6 +324,7 @@ type TResponse = {
 }
 
 export type Client = {
+  baseUri?: string
   execute<T extends object = any>(request: ClientRequest): Promise<ClientResult<T>>
   process<T extends object = any>(
     request: ClientRequest,

--- a/packages/sdk-client-v3/tests/client.test/client.test.ts
+++ b/packages/sdk-client-v3/tests/client.test/client.test.ts
@@ -20,7 +20,9 @@ const createPayloadResult = (tot: number, startingId = 0) => ({
 
 describe('validate options', () => {
   test('middlewares is required', () => {
-    expect(() => createClient(null)).toThrow('Missing required options')
+    expect(() => createClient({} as any)).toThrow(
+      'You need to provide at least one middleware'
+    )
   })
 
   test('middlewares must be an array', () => {


### PR DESCRIPTION
### Summary
Make the platform sdk use same host url as that passed into the `httpMiddlewareOptions`

### Completed Tasks
- [x] pass the host url to the platform sdk from the http client configuration