### PR TITLE
[Feat][DEVX-856] Add a Fluent Builder For The `where` Predicate

### DIFF
--- a/.changeset/plenty-lions-argue.md
+++ b/.changeset/plenty-lions-argue.md
@@ -16,4 +16,6 @@ customers.where((customer) =>
 ```
 
 Field names come from the resource, operators from what the field holds, so a predicate the API
-would reject is a compile error.
+would reject is a compile error. Attribute and Custom Field values are descended into for the
+types the schema cannot express (`value(centAmount = 999 and currencyCode = "EUR")`), and a
+GeoJSON field is matched with `withinCircle(longitude, latitude, radiusInMeters)`.

--- a/.changeset/plenty-lions-argue.md
+++ b/.changeset/plenty-lions-argue.md
@@ -1,0 +1,19 @@
+---
+'@commercetools/graphql-sdk': patch
+---
+
+Add an optional fluent builder for the `where` query predicate.
+
+`where` keeps taking a predicate string exactly as before, and now also takes a callback that
+builds one through a checked builder derived from the resource being filtered:
+
+```ts
+customers.where((customer) =>
+  customer.firstName
+    .is('Martha')
+    .and(customer.addresses((address) => address.city.is('Berlin')))
+)
+```
+
+Field names come from the resource, operators from what the field holds, so a predicate the API
+would reject is a compile error.

--- a/packages/graphql-sdk/README.md
+++ b/packages/graphql-sdk/README.md
@@ -1,14 +1,12 @@
 # @commercetools/graphql-sdk
 
-GraphQL support for the commercetools TypeScript SDK, with a schema derived query builder.
-
-This is the counterpart of the Java SDK's `commercetools-graphql-api` module and the .NET SDK's
-`commercetools.Sdk.GraphQL.Api` project: one package, one entry point, one client.
+GraphQL support for the commercetools TypeScript SDK, with a schema derived query builder: one
+package, one entry point, one client.
 
 The generated SDKs already expose the GraphQL endpoint through `apiRoot.graphql().post(...)`, but
-that call takes a `query` string and hands back `data: any`. This package keeps the same transport -
-your existing client, authentication, middlewares, retries and correlation ids - and adds the typing
-on top.
+that call takes a `query` string and hands back `data: any`. This package adds the typing on top
+while keeping the same transport: your existing client, authentication, middlewares, retries and
+correlation ids.
 
 ## Installation
 
@@ -49,7 +47,7 @@ data.customers.results[0].email // string
 Arguments and projected fields are chained the same way; the builder tells them apart from the
 schema. Autocomplete works at every step, and the result type contains exactly the fields chained.
 
-The emitted document is parameterised - arguments become GraphQL variables, never string
+The emitted document is parameterised: arguments become GraphQL variables, never string
 interpolation:
 
 ```graphql
@@ -66,38 +64,82 @@ query ($v1: String, $v2: [String!], $v3: Int) {
 }
 ```
 
-### Compared with the other SDKs
+The result contains **only the fields you projected**, so reading a field that was never selected
+is a compile error rather than a `null` at runtime.
 
-```java
-// Java
-GraphQL.customers(query -> query.sort(singletonList("id asc")).where("firstName=\"Martha\""))
-       .projection(root -> root.results().firstName().lastName().email())
-```
+List arguments take a list: `.sort(['lastName asc'])`.
 
-```csharp
-// .NET
-var sort = new[] { "id asc" };
-client.Query(o => o.Customers(where: "firstName=\"Martha\"", sort: sort,
-    selector: c => new { Results = c.Results(r => new { r.FirstName, r.LastName, r.Email }) }))
-```
+The `where` predicate can be a string, or built through the
+[predicate builder](#the-where-predicate).
+
+### The `where` predicate
+
+`where` takes a [Query Predicate](https://docs.commercetools.com/api/predicates/query) string, and
+it always will. That is the escape hatch for anything the builder below does not express:
 
 ```ts
-// TypeScript
-graphQL.query({
-  customers: (customers) =>
-    customers
-      .where('firstName="Martha"')
-      .sort(['id asc'])
-      .results((result) => result.firstName().lastName().email()),
-})
+customers.where('firstName="Martha"')
 ```
 
-One deliberate difference from Java: the result contains **only the fields you projected**. In Java
-the projection roots hand back the full `Customer`, so `getCustomerNumber()` compiles even when it
-was never projected and quietly returns `null`. Here that is a compile error.
+It also takes a callback, which builds the same string through a checked builder:
 
-List arguments take a list, as they do in Java (`singletonList("id asc")`) and .NET
-(`new[] { "id asc" }`): `.sort(['lastName asc'])`.
+```ts
+const data = await graphQL
+  .query({
+    customers: (customers) =>
+      customers
+        .where((customer) =>
+          customer.firstName
+            .is('Martha')
+            .and(customer.addresses((address) => address.city.is('Berlin')))
+            .and(customer.customerGroup((group) => group.id.is(goldGroupId)))
+        )
+        .sort(['lastName asc'])
+        .limit(20)
+        .results((result) => result.firstName().lastName().email()),
+  })
+  .executeOrThrow()
+```
+
+which sends
+
+```
+(firstName = "Martha") and (addresses(city = "Berlin")) and (customerGroup(id = "..."))
+```
+
+Field names come from the resource being filtered, and the operators from what the field holds, so
+the operators are the ones the API accepts for that field:
+
+```ts
+customer.firstName.isIn(['Peter', 'Barbara']) //  firstName in ("Peter", "Barbara")
+customer.version.isGreaterThan(10) //             version > 10
+customer.isEmailVerified.is(true) //              isEmailVerified = true
+customer.shippingAddressIds.containsAny(ids) //   shippingAddressIds contains any (...)
+customer.addresses.isEmpty() //                   addresses is empty
+customer.key.isNotDefined() //                    key is not defined
+category.name.locale('en').is('Peter') //         name(en = "Peter")
+customer.custom((c) => c.field('size').is('M')) // custom(fields(size = "M"))
+not(customer.isEmailVerified.is(true)) //         not (isEmailVerified = true)
+```
+
+`and` and `or` parenthesise each operand, so the grouping is in the predicate rather than left to
+the reader. `not` is imported from the package.
+
+A predicate the API would reject is a compile error, including the two that are easy to get wrong:
+a Reference exposes only `id` and `typeId` inside a predicate, never the fields of the resource it
+points at, and a localized field is addressed per locale.
+
+```ts
+customer.customerGroup((group) => group.name.is('wholesale')) // compile error
+category.name.is('Peter') //                                     compile error
+```
+
+Two caveats. Where the GraphQL schema renames a field, the builder uses the name the predicate
+needs, so `attributesRaw` is offered as `attributes`, matching
+`variants(attributes(name = "color" and value = "red"))`. A handful of schema fields, though, have
+no counterpart in the response representation a predicate is evaluated against, and are offered
+even though the API will reject them. Query endpoints also restrict predicates to a documented
+subset of fields, which is not machine readable, so the builder does not enforce it.
 
 ### Nesting
 
@@ -117,8 +159,7 @@ graphQL.query({
 
 ### Every scalar field
 
-`all()` selects every scalar field of a type, the closest equivalent of Java's unprojected response
-models:
+`all()` selects every scalar field of a type:
 
 ```ts
 graphQL.query({
@@ -139,9 +180,9 @@ await graphQL
 
 ## Raw operations
 
-`rawQuery()` is the escape hatch for an operation the builder does not express, the counterpart of
-the Java SDK's `GraphQL.query(String)`. It lives on the same client, returns the same request type
-and goes through the same transport - queries and mutations both:
+`rawQuery()` is the escape hatch for an operation the builder does not express. It lives on the
+same client, returns the same request type and goes through the same transport, for queries and
+mutations both:
 
 ```ts
 const { body } = await graphQL
@@ -185,9 +226,8 @@ in [commercetools-api-reference](https://github.com/commercetools/commercetools-
 with the `implements` clause stripped from `type Query`.
 
 Keeping it current is not a manual job. The `SDK Generator` workflow in that repository runs on
-every change to `api-specs/**`, copies the schema into this package and then runs `make build` —
-exactly what it already does for the Java and .NET SDKs. The refresh arrives as part of the usual
-`build(codegen): updating SDK` pull request.
+every change to `api-specs/**`, copies the schema into this package and then runs `make build`. The
+refresh arrives as part of the usual `build(codegen): updating SDK` pull request.
 
 To refresh it by hand, or after editing the schema locally:
 
@@ -196,10 +236,8 @@ make gen_graphql_builder
 ```
 
 This runs [genql](https://genql.dev) over the schema and rewrites `src/builder/generated`. It is
-also part of `make build`, so the generated client can never drift from the schema next to it.
-The Java and .NET SDKs get that for free because they generate their client at compile time (DGS
-codegen and the ZeroQL source generator); here the generated client is committed, so the build
-chain has to refresh it.
+also part of `make build`, so the generated client can never drift from the schema next to it. The
+generated client is committed rather than produced at compile time, which is why the build chain
+has to refresh it.
 
-The scalar mapping matches those two SDKs (`Long` → `number`, `Country`/`Locale` → `string`,
-`Json` → `unknown`, and so on).
+Scalars map as `Long` → `number`, `Country`/`Locale` → `string`, `Json` → `unknown`, and so on.

--- a/packages/graphql-sdk/README.md
+++ b/packages/graphql-sdk/README.md
@@ -120,10 +120,29 @@ customer.key.isNotDefined() //                    key is not defined
 category.name.locale('en').is('Peter') //         name(en = "Peter")
 customer.custom((c) => c.field('size').is('M')) // custom(fields(size = "M"))
 not(customer.isEmailVerified.is(true)) //         not (isEmailVerified = true)
+channel.geoLocation.withinCircle(13.3, 52.5, 1000) // geoLocation within circle(13.3, 52.5, 1000)
 ```
 
 `and` and `or` parenthesise each operand, so the grouping is in the predicate rather than left to
-the reader. `not` is imported from the package.
+the reader. `not` is imported from the package. A geolocation is compared against a circle given
+as longitude, latitude and a radius in metres, which the API does not accept inside an `or`.
+
+An Attribute or Custom Field value is a `Json` in the schema, so its own fields cannot be checked
+the way a resource's are. Any name is accepted there, and the value is descended into the same way
+an object field is, which is how a Money, Enum or Reference Attribute is matched:
+
+```ts
+variant.attributes((attribute) =>
+  attribute.name
+    .is('price')
+    .and(
+      attribute.value((value) =>
+        value.centAmount.isGreaterThan(999).and(value.currencyCode.is('EUR'))
+      )
+    )
+)
+// attributes((name = "price") and (value((centAmount > 999) and (currencyCode = "EUR"))))
+```
 
 A predicate the API would reject is a compile error, including the two that are easy to get wrong:
 a Reference exposes only `id` and `typeId` inside a predicate, never the fields of the resource it

--- a/packages/graphql-sdk/src/builder/chain.ts
+++ b/packages/graphql-sdk/src/builder/chain.ts
@@ -1,11 +1,12 @@
 /**
  * A fluent, chainable projection builder over the generated schema selection types.
  *
- * This is the TypeScript counterpart of the Java SDK's projection roots
- * (`root -> root.results().firstName()`) and the .NET SDK's ZeroQL selectors
- * (`c => new { c.FirstName }`), with one difference: the accumulated selection is tracked
- * in the type, so the result contains exactly the fields that were chained and nothing else.
+ * The accumulated selection is tracked in the type, so the result contains exactly the fields
+ * that were chained and nothing else.
  */
+
+import type { HasWhereResource, Predicate, WhereBuilder } from './where'
+import { resolveWhere } from './where'
 
 /** Marker carrying the accumulated selection of a chain. */
 declare const SELECTION: unique symbol
@@ -37,7 +38,7 @@ type FieldsOf<TSelection> = Omit<
 >
 
 /**
- * A scalar field that also takes arguments - a localized string such as `name(locale:)` -
+ * A scalar field that also takes arguments, such as a localized string like `name(locale:)`,
  * is `{ __args: ... } | boolean | number`, so the union carrying `boolean` is what marks a
  * field as scalar, not the whole type being assignable to it.
  */
@@ -46,14 +47,45 @@ type IsScalarField<TField> = boolean extends TField ? true : false
 /** The `__args` member of a field type, for the fields that have one. */
 type ArgsPartOf<TField> = Extract<NonNullable<TField>, { __args: any }>
 
-type ArgMethods<TSelection, TFields, TArgs> = {
-  [TArg in keyof ArgsOf<TSelection>]-?: (
-    value: NonNullable<ArgsOf<TSelection>[TArg]>
-  ) => Chain<
-    TSelection,
-    TFields,
-    TArgs & { [P in TArg]: NonNullable<ArgsOf<TSelection>[TArg]> }
-  >
+/**
+ * `where` takes a [Query Predicate](https://docs.commercetools.com/api/predicates/query), which
+ * the builder in `./where` can assemble. The predicate string stays a plain overload, so it is
+ * still the way to express anything the builder does not cover, and existing calls are untouched.
+ *
+ * The builder overload only appears once the resource being filtered is known, which it is for
+ * every paged query field, from the element type of its `results`.
+ */
+type WhereMethod<TSelection, TFields, TArgs, TResult, TPredicate> =
+  HasWhereResource<TResult> extends true
+    ? {
+        (
+          predicate: TPredicate
+        ): Chain<TSelection, TFields, TArgs & { where: TPredicate }, TResult>
+        (
+          build: WhereBuilder<TResult>
+        ): Chain<TSelection, TFields, TArgs & { where: TPredicate }, TResult>
+      }
+    : (
+        predicate: TPredicate
+      ) => Chain<TSelection, TFields, TArgs & { where: TPredicate }, TResult>
+
+type ArgMethods<TSelection, TFields, TArgs, TResult> = {
+  [TArg in keyof ArgsOf<TSelection>]-?: TArg extends 'where'
+    ? WhereMethod<
+        TSelection,
+        TFields,
+        TArgs,
+        TResult,
+        NonNullable<ArgsOf<TSelection>[TArg]>
+      >
+    : (
+        value: NonNullable<ArgsOf<TSelection>[TArg]>
+      ) => Chain<
+        TSelection,
+        TFields,
+        TArgs & { [P in TArg]: NonNullable<ArgsOf<TSelection>[TArg]> },
+        TResult
+      >
 }
 
 /**
@@ -66,16 +98,30 @@ type ScalarFieldMethod<
   TSelection,
   TFields,
   TArgs,
+  TResult,
   TField extends PropertyKey,
 > = [ArgsPartOf<TFieldType>] extends [never]
-  ? () => Chain<TSelection, TFields & { [P in TField]: true }, TArgs>
+  ? () => Chain<TSelection, TFields & { [P in TField]: true }, TArgs, TResult>
   : (
       select?: (
         chain: Chain<ArgsPartOf<TFieldType>, {}, {}>
       ) => ChainMarker<any, any>
-    ) => Chain<TSelection, TFields & { [P in TField]: true }, TArgs>
+    ) => Chain<TSelection, TFields & { [P in TField]: true }, TArgs, TResult>
 
-type FieldMethods<TSelection, TFields, TArgs> = {
+/**
+ * The response type of a field, which is what the `where` of a nested chain is derived from.
+ * A list resolves to its element type, so `results` on a query result hands back the resource
+ * itself. `unknown` when the response type is not known, which switches `where` back to taking
+ * only a predicate string.
+ */
+export type ResultFieldOf<TResult, TField> =
+  TField extends keyof NonNullable<TResult>
+    ? NonNullable<TResult>[TField] extends readonly (infer TItem)[]
+      ? TItem
+      : NonNullable<NonNullable<TResult>[TField]>
+    : unknown
+
+type FieldMethods<TSelection, TFields, TArgs, TResult> = {
   [TField in keyof FieldsOf<TSelection>]-?: IsScalarField<
     FieldsOf<TSelection>[TField]
   > extends true
@@ -84,36 +130,48 @@ type FieldMethods<TSelection, TFields, TArgs> = {
         TSelection,
         TFields,
         TArgs,
+        TResult,
         TField
       >
     : <TSubChain extends ChainMarker<any, any>>(
         select: (
-          chain: Chain<NonNullable<FieldsOf<TSelection>[TField]>, {}, {}>
+          chain: Chain<
+            NonNullable<FieldsOf<TSelection>[TField]>,
+            {},
+            {},
+            ResultFieldOf<TResult, TField>
+          >
         ) => TSubChain
       ) => Chain<
         TSelection,
         TFields & { [P in TField]: SelectionOf<TSubChain> },
-        TArgs
+        TArgs,
+        TResult
       >
 }
 
-interface ChainExtras<TSelection, TFields, TArgs> {
+interface ChainExtras<TSelection, TFields, TArgs, TResult> {
   /**
-   * Selects every scalar field of this type, the equivalent of the Java SDK's
-   * unprojected response models.
+   * Selects every scalar field of this type.
    */
-  all(): Chain<TSelection, TFields & { __scalar: true }, TArgs>
+  all(): Chain<TSelection, TFields & { __scalar: true }, TArgs, TResult>
   /** Selects the `__typename` meta field. */
-  typename(): Chain<TSelection, TFields & { __typename: true }, TArgs>
+  typename(): Chain<TSelection, TFields & { __typename: true }, TArgs, TResult>
 }
 
-export type Chain<TSelection, TFields = {}, TArgs = {}> = ArgMethods<
+/**
+ * `TResult` is the response type matching `TSelection`, carried along so that `where` knows
+ * which resource it filters over. It defaults to `unknown`, which leaves every member behaving
+ * exactly as it did before it was threaded through.
+ */
+export type Chain<
   TSelection,
-  TFields,
-  TArgs
-> &
-  FieldMethods<TSelection, TFields, TArgs> &
-  ChainExtras<TSelection, TFields, TArgs> &
+  TFields = {},
+  TArgs = {},
+  TResult = unknown,
+> = ArgMethods<TSelection, TFields, TArgs, TResult> &
+  FieldMethods<TSelection, TFields, TArgs, TResult> &
+  ChainExtras<TSelection, TFields, TArgs, TResult> &
   ChainMarker<TFields, TArgs>
 
 /** Reads the plain genql selection object out of a chain at runtime. */
@@ -131,6 +189,12 @@ function build(state: ChainState): Record<string, unknown> {
 }
 
 /**
+ * Arguments whose string value a callback can build instead, rather than the callback being a
+ * projection. `where` takes a query predicate, which is what `./where` assembles.
+ */
+const PREDICATE_ARGS = new Set(['where'])
+
+/**
  * Creates a chain.
  *
  * Which kind of member is being called is decided from the call itself, which is
@@ -139,6 +203,9 @@ function build(state: ChainState): Record<string, unknown> {
  * - no argument            -> a scalar field, selected as `true`
  * - a function argument    -> an object field, recursed into
  * - any other argument     -> a field argument, collected into `__args`
+ *
+ * The one exception is a {@link PREDICATE_ARGS} argument given a function, which builds the
+ * argument's own string rather than projecting anything.
  */
 export function createChain(): any {
   const state: ChainState = { fields: {}, args: {} }
@@ -180,6 +247,13 @@ export function createChain(): any {
           }
 
           if (typeof value === 'function') {
+            if (PREDICATE_ARGS.has(property)) {
+              state.args[property] = resolveWhere(
+                value as (resource: unknown) => Predicate
+              )
+              return proxy
+            }
+
             state.fields[property] = resolveChain(
               (value as (chain: unknown) => unknown)(createChain())
             )

--- a/packages/graphql-sdk/src/builder/where.ts
+++ b/packages/graphql-sdk/src/builder/where.ts
@@ -1,0 +1,411 @@
+/**
+ * A fluent builder for the [Query Predicate](https://docs.commercetools.com/api/predicates/query)
+ * that the `where` argument takes.
+ *
+ * It is derived from the response types genql already generates, so there is no second artefact
+ * to keep in step with the schema.
+ *
+ * It is entirely optional. `where` keeps taking a predicate string, which stays the escape hatch
+ * for anything this builder does not express:
+ *
+ * ```ts
+ * customers.where('firstName="Martha"')
+ * customers.where((customer) => customer.firstName.is('Martha'))
+ * ```
+ */
+
+/** Marker making a built predicate distinguishable from any other object. */
+declare const PREDICATE: unique symbol
+
+/** The predicate string carried by a {@link Predicate}, read back by {@link resolveWhere}. */
+const SOURCE = Symbol.for('@commercetools/graphql-sdk/predicate-source')
+
+/**
+ * A built predicate. Combine with {@link Predicate.and}, {@link Predicate.or} and {@link not},
+ * or read the predicate string off it with `String(predicate)`.
+ */
+export interface Predicate {
+  readonly [PREDICATE]?: true
+  /** `(this) and (other)` */
+  and(...others: Predicate[]): Predicate
+  /** `(this) or (other)` */
+  or(...others: Predicate[]): Predicate
+  /** The predicate string, which is what ends up in the `where` argument. */
+  toString(): string
+}
+
+function predicate(source: string): Predicate {
+  return {
+    [SOURCE]: source,
+    and: (...others: Predicate[]) => combine('and', source, others),
+    or: (...others: Predicate[]) => combine('or', source, others),
+    toString: () => source,
+  } as unknown as Predicate
+}
+
+/**
+ * Every operand is parenthesised. `a and b or c` groups differently depending on the reader, so
+ * the emitted predicate says which grouping was meant instead of relying on precedence.
+ */
+function combine(
+  operator: 'and' | 'or',
+  source: string,
+  others: Predicate[]
+): Predicate {
+  return predicate(
+    [source, ...others.map(sourceOf)]
+      .map((part) => `(${part})`)
+      .join(` ${operator} `)
+  )
+}
+
+/** `not (...)`, the negation of any other predicate. */
+export function not(inner: Predicate): Predicate {
+  return predicate(`not (${sourceOf(inner)})`)
+}
+
+function sourceOf(value: unknown): string {
+  const source = (value as Record<symbol, unknown> | null)?.[SOURCE]
+
+  if (typeof source !== 'string') {
+    throw new TypeError(
+      'A `where` callback must return a predicate, for example `customer => customer.firstName.is("Martha")`.'
+    )
+  }
+
+  return source
+}
+
+// ----------------------------------------------------------------- the values
+
+type Literal = string | number | boolean
+
+/**
+ * Predicate values are literals in the predicate string itself, so a string carrying a quote or
+ * a backslash has to be escaped rather than passed through.
+ */
+function literal(value: Literal): string {
+  return typeof value === 'string'
+    ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+    : String(value)
+}
+
+// ------------------------------------------------------------- the leaf types
+
+/** Available on every field, whatever its type. */
+export interface Defined {
+  /** `field is defined` */
+  isDefined(): Predicate
+  /** `field is not defined` */
+  isNotDefined(): Predicate
+}
+
+/** Available on every collection field. */
+export interface Emptiable extends Defined {
+  /** `field is empty` */
+  isEmpty(): Predicate
+  /** `field is not empty` */
+  isNotEmpty(): Predicate
+}
+
+export interface Equality<TValue> extends Defined {
+  /** `field = value`. An exact match, never a substring match. */
+  is(value: TValue): Predicate
+  /** `field != value` */
+  isNot(value: TValue): Predicate
+  /** `field in (a, b)`, which is markedly cheaper than chaining `or`. */
+  isIn(values: readonly TValue[]): Predicate
+  /** `field not in (a, b)` */
+  isNotIn(values: readonly TValue[]): Predicate
+}
+
+export interface Comparable<TValue> extends Equality<TValue> {
+  /** `field < value` */
+  isLessThan(value: TValue): Predicate
+  /** `field <= value` */
+  isLessThanOrEqual(value: TValue): Predicate
+  /** `field > value` */
+  isGreaterThan(value: TValue): Predicate
+  /** `field >= value` */
+  isGreaterThanOrEqual(value: TValue): Predicate
+}
+
+export interface CollectionOf<TValue> extends Emptiable {
+  /** `field contains all (a, b)` */
+  containsAll(values: readonly TValue[]): Predicate
+  /** `field contains any (a, b)` */
+  containsAny(values: readonly TValue[]): Predicate
+}
+
+/**
+ * A localized field. Predicates address the locales of a `LocalizedString` directly, as in
+ * `name(en = "Peter")`, so this is not a plain string field.
+ */
+export interface Localized {
+  /** `field(<locale> = value)`, for example `name(en = "Peter")` */
+  locale(locale: string): Equality<string>
+}
+
+/**
+ * A field the schema types as `Json`, such as an Attribute or Custom Field value. The API
+ * compares it against whatever the field actually holds, so every literal is accepted.
+ */
+export interface AnyValue extends Comparable<Literal>, Localized {}
+
+/**
+ * A reference field. Inside a predicate a Reference exposes only `id` and `typeId`, and a
+ * KeyReference only `key` and `typeId`, never the fields of the resource being pointed at.
+ *
+ * @see https://docs.commercetools.com/api/predicates/query#references-in-query-predicates
+ */
+export type ReferencePredicate<TReference> = {
+  readonly [TField in Exclude<keyof TReference, '__typename'>]: Equality<
+    Extract<TReference[TField], string>
+  >
+}
+
+/** `custom(fields(<name> = value))`, the predicate form of Custom Fields. */
+export interface CustomFields {
+  /**
+   * `custom(fields(<name> = value))`, where `name` is the name in the FieldDefinition.
+   *
+   * The schema exposes Custom Fields as untyped name/value pairs, so the field name is a
+   * string here rather than a member of this type.
+   */
+  field(name: string): AnyValue
+}
+
+// ------------------------------------------------------------ field selection
+
+type Nullable<T> = Exclude<T, null | undefined>
+
+type ElementOf<T> = T extends readonly (infer TItem)[] ? TItem : T
+
+/**
+ * genql renames a handful of fields that carry a payload the GraphQL schema cannot type, and
+ * the predicate has to use the name from the REST representation it is evaluated against.
+ * `attributesRaw` is `attributes` in `variants(attributes(name = "color" and value = "red"))`.
+ */
+interface PredicateNames {
+  attributesRaw: 'attributes'
+  interfaceInteractionsRaw: 'interfaceInteractions'
+}
+
+type PredicateName<TField> = TField extends keyof PredicateNames
+  ? PredicateNames[TField]
+  : TField
+
+const PREDICATE_NAMES: Record<string, string> = {
+  attributesRaw: 'attributes',
+  interfaceInteractionsRaw: 'interfaceInteractions',
+}
+
+/**
+ * Fields the schema only exposes to make querying convenient. `nameAllLocales` is the projection
+ * of a localized `name`, `customerGroupRef` the unresolved form of `customerGroup`, and
+ * `customFieldsRaw` is reached through {@link CustomFields.field} instead. None of the three is
+ * addressable in a predicate.
+ */
+type Hidden<TResource> = Extract<
+  keyof TResource,
+  | '__typename'
+  | 'customFieldsRaw'
+  | `${string}AllLocales`
+  | `${string}Ref`
+  | `${string}Refs`
+>
+
+/** `nameAllLocales` next to `name` is how the schema marks `name` as localized. */
+type IsLocalized<
+  TResource,
+  TField extends string,
+> = `${TField}AllLocales` extends keyof TResource ? true : false
+
+/** `customerGroupRef` next to `customerGroup`, `storesRef` next to `stores`. */
+type ReferenceFieldOf<
+  TResource,
+  TField extends string,
+> = `${TField}Ref` extends keyof TResource
+  ? `${TField}Ref`
+  : `${TField}Refs` extends keyof TResource
+    ? `${TField}Refs`
+    : never
+
+/** The `Reference` or `KeyReference` a field resolves from, if it resolves from one. */
+type ReferenceTargetOf<TResource, TField extends string> = [
+  ReferenceFieldOf<TResource, TField>,
+] extends [never]
+  ? never
+  : ElementOf<
+      Nullable<TResource[ReferenceFieldOf<TResource, TField> & keyof TResource]>
+    >
+
+/**
+ * A leaf is a field a predicate compares against a literal. An object field has none of these
+ * operators, which is what tells the two apart.
+ */
+type LeafFor<TValue> = [TValue] extends [never]
+  ? never
+  : unknown extends TValue
+    ? AnyValue
+    : [TValue] extends [boolean]
+      ? Equality<boolean>
+      : [TValue] extends [number]
+        ? Comparable<number>
+        : [TValue] extends [string]
+          ? Comparable<string>
+          : never
+
+/**
+ * An object is descended into by calling the field with a callback, mirroring the parentheses
+ * of `addresses(city = "Berlin")`. `isDefined()` stays available on the field itself.
+ */
+type ObjectField<TObject> = ((
+  select: (nested: ResourcePredicate<TObject>) => Predicate
+) => Predicate) &
+  Defined
+
+type ObjectArrayField<TItem> = ((
+  select: (item: ResourcePredicate<TItem>) => Predicate
+) => Predicate) &
+  Emptiable
+
+type ReferenceField<TReference> = ((
+  select: (reference: ReferencePredicate<TReference>) => Predicate
+) => Predicate) &
+  Defined
+
+/**
+ * What a `where` callback, and every nested one, receives: the predicate members of a resource,
+ * plus {@link CustomFields.field} on the Custom Fields container the schema cannot type.
+ */
+export type ResourcePredicate<TResource> = PredicateRoot<TResource> &
+  ('customFieldsRaw' extends keyof TResource ? CustomFields : {})
+
+type PlainFieldFor<TResource, TField extends keyof TResource> =
+  Nullable<TResource[TField]> extends readonly (infer TItem)[]
+    ? [LeafFor<TItem>] extends [never]
+      ? ObjectArrayField<TItem>
+      : CollectionOf<TItem>
+    : [LeafFor<Nullable<TResource[TField]>>] extends [never]
+      ? ObjectField<Nullable<TResource[TField]>>
+      : LeafFor<Nullable<TResource[TField]>>
+
+type FieldFor<TResource, TField extends keyof TResource & string> =
+  IsLocalized<TResource, TField> extends true
+    ? Localized
+    : [ReferenceTargetOf<TResource, TField>] extends [never]
+      ? PlainFieldFor<TResource, TField>
+      : ReferenceField<ReferenceTargetOf<TResource, TField>>
+
+/**
+ * The predicate members of a resource: one per field of its response representation, typed by
+ * what that field holds.
+ */
+export type PredicateRoot<TResource> = {
+  readonly [
+    TField in Extract<
+      Exclude<keyof TResource, Hidden<TResource>>,
+      string
+    > as PredicateName<TField>
+  ]: FieldFor<TResource, TField>
+}
+
+/** The resource a `where` predicate filters over: the element type of `results`. */
+export type WhereResourceOf<TResult> =
+  Nullable<TResult> extends { results: readonly (infer TItem)[] }
+    ? TItem
+    : never
+
+/** The callback form of `where`, as opposed to a predicate string. */
+export type WhereBuilder<TResult> = (
+  resource: ResourcePredicate<WhereResourceOf<TResult>>
+) => Predicate
+
+/** Whether a `where` on this result type can offer the builder at all. */
+export type HasWhereResource<TResult> = [WhereResourceOf<TResult>] extends [
+  never,
+]
+  ? false
+  : true
+
+// ------------------------------------------------------------------ the runtime
+
+/**
+ * The operators of one field. `wrap` is how the expression is embedded in its parent, which is
+ * what turns `en = "Peter"` into `name(en = "Peter")` for a localized field.
+ */
+function leaf(
+  subject: string,
+  wrap: (expression: string) => string = (expression) => expression
+): any {
+  const binary = (operator: string) => (value: Literal) =>
+    predicate(wrap(`${subject} ${operator} ${literal(value)}`))
+
+  const set = (operator: string) => (values: readonly Literal[]) =>
+    predicate(
+      wrap(`${subject} ${operator} (${values.map(literal).join(', ')})`)
+    )
+
+  const bare = (suffix: string) => () => predicate(wrap(`${subject} ${suffix}`))
+
+  return {
+    is: binary('='),
+    isNot: binary('!='),
+    isLessThan: binary('<'),
+    isLessThanOrEqual: binary('<='),
+    isGreaterThan: binary('>'),
+    isGreaterThanOrEqual: binary('>='),
+    isIn: set('in'),
+    isNotIn: set('not in'),
+    containsAll: set('contains all'),
+    containsAny: set('contains any'),
+    isEmpty: bare('is empty'),
+    isNotEmpty: bare('is not empty'),
+    isDefined: bare('is defined'),
+    isNotDefined: bare('is not defined'),
+    locale: (locale: string) =>
+      leaf(locale, (expression) => `${subject}(${expression})`),
+  }
+}
+
+/**
+ * Creates the object a `where` callback receives.
+ *
+ * Which kind of member is being used is decided from the call itself, the same way the
+ * projection chain decides it:
+ *
+ * - `field.is(value)`   -> a leaf, compared against a literal
+ * - `field(inner)`      -> an object, array or reference, descended into
+ * - `field('name')`     -> {@link CustomFields.field}, the one member taking a field name
+ */
+export function createPredicateRoot(): any {
+  return new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (typeof property !== 'string') {
+          return undefined
+        }
+
+        if (property === 'field') {
+          return (name: string) =>
+            leaf(name, (expression) => `fields(${expression})`)
+        }
+
+        const name = PREDICATE_NAMES[property] ?? property
+
+        return Object.assign(
+          (select: (inner: unknown) => Predicate) =>
+            predicate(`${name}(${sourceOf(select(createPredicateRoot()))})`),
+          leaf(name)
+        )
+      },
+    }
+  )
+}
+
+/** Runs a `where` callback and returns the predicate string it built. */
+export function resolveWhere(build: (resource: any) => Predicate): string {
+  return sourceOf(build(createPredicateRoot()))
+}

--- a/packages/graphql-sdk/src/builder/where.ts
+++ b/packages/graphql-sdk/src/builder/where.ts
@@ -14,6 +14,8 @@
  * ```
  */
 
+import type { Geometry } from './generated'
+
 /** Marker making a built predicate distinguishable from any other object. */
 declare const PREDICATE: unique symbol
 
@@ -148,9 +150,54 @@ export interface Localized {
 
 /**
  * A field the schema types as `Json`, such as an Attribute or Custom Field value. The API
- * compares it against whatever the field actually holds, so every literal is accepted.
+ * compares it against whatever the field actually holds, so every literal is accepted, and the
+ * value is descended into when what it holds is an object.
+ *
+ * The names inside such a value are not in the schema, so they cannot be checked the way the
+ * fields of a resource are. Every one of them is again an {@link AnyValue}.
  */
-export interface AnyValue extends Comparable<Literal>, Localized {}
+export interface JsonFields {
+  readonly [name: string]: AnyValue
+}
+
+/**
+ * A field the schema types as `Json`, such as an Attribute or Custom Field value. The API
+ * compares it against whatever the field actually holds, so every literal is accepted.
+ *
+ * Values that hold an object are descended into, which is how a Money, Enum or Reference
+ * Attribute is addressed:
+ *
+ * ```ts
+ * variant.attributes((a) =>
+ *   a.name
+ *     .is('price')
+ *     .and(a.value((v) => v.centAmount.is(999).and(v.currencyCode.is('EUR'))))
+ * )
+ * ```
+ *
+ * @see https://docs.commercetools.com/api/predicates/query#on-attributes
+ */
+export interface AnyValue extends Comparable<Literal>, Localized {
+  /** `field(<inner>)`, for example `value(centAmount = 999 and currencyCode = "EUR")`. */
+  (select: (value: JsonFields) => Predicate): Predicate
+}
+
+/**
+ * A GeoJSON field, which a predicate compares only against a circle. The two first parameters
+ * are the longitude and the latitude of its centre, the third its radius in metres.
+ *
+ * The API does not support this inside an `or`, and orders the results by distance.
+ *
+ * @see https://docs.commercetools.com/api/predicates/query#query-predicates-by-example
+ */
+export interface GeoLocation extends Defined {
+  /** `field within circle(longitude, latitude, radius)` */
+  withinCircle(
+    longitude: number,
+    latitude: number,
+    radiusInMeters: number
+  ): Predicate
+}
 
 /**
  * A reference field. Inside a predicate a Reference exposes only `id` and `typeId`, and a
@@ -294,9 +341,11 @@ type PlainFieldFor<TResource, TField extends keyof TResource> =
 type FieldFor<TResource, TField extends keyof TResource & string> =
   IsLocalized<TResource, TField> extends true
     ? Localized
-    : [ReferenceTargetOf<TResource, TField>] extends [never]
-      ? PlainFieldFor<TResource, TField>
-      : ReferenceField<ReferenceTargetOf<TResource, TField>>
+    : [Nullable<TResource[TField]>] extends [Geometry]
+      ? GeoLocation
+      : [ReferenceTargetOf<TResource, TField>] extends [never]
+        ? PlainFieldFor<TResource, TField>
+        : ReferenceField<ReferenceTargetOf<TResource, TField>>
 
 /**
  * The predicate members of a resource: one per field of its response representation, typed by
@@ -332,8 +381,13 @@ export type HasWhereResource<TResult> = [WhereResourceOf<TResult>] extends [
 // ------------------------------------------------------------------ the runtime
 
 /**
- * The operators of one field. `wrap` is how the expression is embedded in its parent, which is
- * what turns `en = "Peter"` into `name(en = "Peter")` for a localized field.
+ * One field: the operators it can be compared with, and the descent into whatever it holds.
+ * `wrap` is how the expression is embedded in its parent, which is what turns `en = "Peter"`
+ * into `name(en = "Peter")` for a localized field.
+ *
+ * The result is callable because descending is a call, `addresses(city = "Berlin")`. Which of
+ * the two a field allows is decided by the type; at run time both are always here, since the
+ * names inside a value the schema types as `Json` are not known until they are used.
  */
 function leaf(
   subject: string,
@@ -349,7 +403,10 @@ function leaf(
 
   const bare = (suffix: string) => () => predicate(wrap(`${subject} ${suffix}`))
 
-  return {
+  const descend = (select: (inner: unknown) => Predicate) =>
+    predicate(wrap(`${subject}(${sourceOf(select(createPredicateRoot()))})`))
+
+  return Object.assign(descend, {
     is: binary('='),
     isNot: binary('!='),
     isLessThan: binary('<'),
@@ -366,7 +423,17 @@ function leaf(
     isNotDefined: bare('is not defined'),
     locale: (locale: string) =>
       leaf(locale, (expression) => `${subject}(${expression})`),
-  }
+    withinCircle: (
+      longitude: number,
+      latitude: number,
+      radiusInMeters: number
+    ) =>
+      predicate(
+        wrap(
+          `${subject} within circle(${longitude}, ${latitude}, ${radiusInMeters})`
+        )
+      ),
+  })
 }
 
 /**
@@ -393,13 +460,7 @@ export function createPredicateRoot(): any {
             leaf(name, (expression) => `fields(${expression})`)
         }
 
-        const name = PREDICATE_NAMES[property] ?? property
-
-        return Object.assign(
-          (select: (inner: unknown) => Predicate) =>
-            predicate(`${name}(${sourceOf(select(createPredicateRoot()))})`),
-          leaf(name)
-        )
+        return leaf(PREDICATE_NAMES[property] ?? property)
       },
     }
   )

--- a/packages/graphql-sdk/src/client/graphql-client.ts
+++ b/packages/graphql-sdk/src/client/graphql-client.ts
@@ -1,4 +1,9 @@
-import type { Chain, ChainMarker, SelectionOf } from '../builder/chain'
+import type {
+  Chain,
+  ChainMarker,
+  ResultFieldOf,
+  SelectionOf,
+} from '../builder/chain'
 import { createChain, resolveChain } from '../builder/chain'
 import {
   generateMutationOp,
@@ -24,10 +29,19 @@ import { GraphQLApiRequest } from './graphql-api-request'
  * ```ts
  * { customers: customers => customers.where('firstName="Martha"').total() }
  * ```
+ *
+ * `TRootResult` is the response type of the root, `Query` or `Mutation`, which is field for
+ * field parallel to its selection type. Pairing the two is what lets `where` offer a predicate
+ * builder for the resource being filtered.
  */
-type RootSelectors<TRootSelection> = {
+type RootSelectors<TRootSelection, TRootResult> = {
   [TField in keyof TRootSelection]?: (
-    chain: Chain<NonNullable<TRootSelection[TField]>, {}, {}>
+    chain: Chain<
+      NonNullable<TRootSelection[TField]>,
+      {},
+      {},
+      ResultFieldOf<TRootResult, TField>
+    >
   ) => ChainMarker<any, any>
 }
 
@@ -69,9 +83,7 @@ function isApiRoot(
  * The typed GraphQL client for the commercetools APIs.
  *
  * Field names, arguments and the shape of the result all come from the commercetools GraphQL
- * schema, so no GraphQL string is written by hand and a typo is a compile error. This is the
- * counterpart of the Java SDK's `commercetools-graphql-api` module and the .NET SDK's
- * `commercetools.Sdk.GraphQL.Api` project.
+ * schema, so no GraphQL string is written by hand and a typo is a compile error.
  *
  * The client does not open its own HTTP connection: every request is handed to the generated
  * request builder, so authentication, middlewares, retries and correlation ids of the api root
@@ -98,8 +110,14 @@ export class GraphQLClient {
    *   })
    *   .executeOrThrow()
    * ```
+   *
+   * `where` also takes a callback, which builds the same predicate through a checked builder:
+   *
+   * ```ts
+   * customers.where(customer => customer.firstName.is('Martha'))
+   * ```
    */
-  public query<TSelectors extends RootSelectors<QueryGenqlSelection>>(
+  public query<TSelectors extends RootSelectors<QueryGenqlSelection, Query>>(
     selectors: TSelectors
   ): GraphQLApiRequest<FieldsSelection<Query, RootResult<TSelectors>>> {
     const operation = generateQueryOp(toSelection(selectors) as any)
@@ -118,7 +136,9 @@ export class GraphQLClient {
    *   .executeOrThrow()
    * ```
    */
-  public mutate<TSelectors extends RootSelectors<MutationGenqlSelection>>(
+  public mutate<
+    TSelectors extends RootSelectors<MutationGenqlSelection, Mutation>,
+  >(
     selectors: TSelectors
   ): GraphQLApiRequest<FieldsSelection<Mutation, RootResult<TSelectors>>> {
     const operation = generateMutationOp(toSelection(selectors) as any)
@@ -127,11 +147,11 @@ export class GraphQLClient {
   }
 
   /**
-   * Escape hatch for an operation that is not expressed through the builder, the counterpart of
-   * the Java SDK's `GraphQL.query(String)`. Queries and mutations both go through it, and the
-   * returned request is the same one {@link query} and {@link mutate} return.
+   * Escape hatch for an operation that is not expressed through the builder. Queries and
+   * mutations both go through it, and the returned request is the same one {@link query} and
+   * {@link mutate} return.
    *
-   * A `TypedDocumentNode` - the interface produced by GraphQL Code Generator and gql.tada - keeps
+   * A `TypedDocumentNode`, the interface produced by GraphQL Code Generator and gql.tada, keeps
    * the variables checked and the response data typed; a plain string resolves to `any`.
    *
    * ```ts
@@ -169,8 +189,7 @@ export class GraphQLClient {
 }
 
 /**
- * Creates a {@link GraphQLClient} on top of an existing api root, the counterpart of the .NET
- * SDK's `apiRoot.GraphQLClient()` extension.
+ * Creates a {@link GraphQLClient} on top of an existing api root.
  *
  * ```ts
  * const apiRoot = createApiBuilderFromCtpClient(client).withProjectKey({ projectKey })

--- a/packages/graphql-sdk/src/index.ts
+++ b/packages/graphql-sdk/src/index.ts
@@ -2,11 +2,33 @@ export { GraphQLApiRequest } from './client/graphql-api-request'
 export { GraphQLClient, createGraphQLClient } from './client/graphql-client'
 export { GraphQLRequestError } from './errors/graphql-request-error'
 export { printDocument, toGraphQLRequestBody } from './utils/print-document'
+export { not } from './builder/where'
 
 export { everything, generateMutationOp, generateQueryOp } from './builder/generated'
 
 export type { TypedDocumentNode } from '@graphql-typed-document-node/core'
-export type { Chain, ChainMarker, SelectionOf } from './builder/chain'
+export type {
+  Chain,
+  ChainMarker,
+  ResultFieldOf,
+  SelectionOf
+} from './builder/chain'
+export type {
+  AnyValue,
+  CollectionOf,
+  Comparable,
+  CustomFields,
+  Defined,
+  Emptiable,
+  Equality,
+  Localized,
+  Predicate,
+  PredicateRoot,
+  ReferencePredicate,
+  ResourcePredicate,
+  WhereBuilder,
+  WhereResourceOf
+} from './builder/where'
 export type {
   FieldsSelection,
   Mutation,

--- a/packages/graphql-sdk/src/index.ts
+++ b/packages/graphql-sdk/src/index.ts
@@ -21,6 +21,8 @@ export type {
   Defined,
   Emptiable,
   Equality,
+  GeoLocation,
+  JsonFields,
   Localized,
   Predicate,
   PredicateRoot,

--- a/packages/graphql-sdk/tests/where.test.ts
+++ b/packages/graphql-sdk/tests/where.test.ts
@@ -1,0 +1,446 @@
+import { ApiRoot } from '@commercetools/platform-sdk'
+import { createGraphQLClient, not } from '../src'
+import type { Predicate, ResourcePredicate } from '../src'
+import type {
+  Cart,
+  Category,
+  Customer,
+  Product,
+} from '../src/builder/generated'
+import { createPredicateRoot, resolveWhere } from '../src/builder/where'
+
+function createApiRoot(body: any = { data: {} }) {
+  const executeRequest = jest.fn().mockResolvedValue({ body, statusCode: 200 })
+  const apiRoot = new ApiRoot({ executeRequest }).withProjectKey({
+    projectKey: 'test-project',
+  })
+
+  return { apiRoot, executeRequest }
+}
+
+/**
+ * Builds a predicate for one resource without going through the client. Typed exactly as the
+ * `where` callback is, so every case below is checked at compile time as well as at run time.
+ */
+function build<TResource>(
+  select: (resource: ResourcePredicate<TResource>) => Predicate
+): string {
+  return resolveWhere(select as (resource: any) => Predicate)
+}
+
+describe('the predicate builder', () => {
+  it('compares a field against a value', () => {
+    expect(build<Customer>((c) => c.firstName.is('Martha'))).toBe(
+      'firstName = "Martha"'
+    )
+    expect(build<Customer>((c) => c.firstName.isNot('Martha'))).toBe(
+      'firstName != "Martha"'
+    )
+  })
+
+  it('compares ranges', () => {
+    expect(build<Customer>((c) => c.version.isLessThan(10))).toBe(
+      'version < 10'
+    )
+    expect(build<Customer>((c) => c.version.isLessThanOrEqual(10))).toBe(
+      'version <= 10'
+    )
+    expect(build<Customer>((c) => c.version.isGreaterThan(10))).toBe(
+      'version > 10'
+    )
+    expect(build<Customer>((c) => c.version.isGreaterThanOrEqual(10))).toBe(
+      'version >= 10'
+    )
+  })
+
+  it('compares dates, which the schema types as strings', () => {
+    expect(
+      build<Customer>((c) => c.dateOfBirth.isGreaterThan('2018-10-12'))
+    ).toBe('dateOfBirth > "2018-10-12"')
+  })
+
+  it('builds set membership', () => {
+    expect(build<Customer>((c) => c.firstName.isIn(['Peter', 'Barbara']))).toBe(
+      'firstName in ("Peter", "Barbara")'
+    )
+    expect(build<Customer>((c) => c.firstName.isNotIn(['Peter']))).toBe(
+      'firstName not in ("Peter")'
+    )
+  })
+
+  it('builds collection membership', () => {
+    expect(
+      build<Customer>((c) => c.shippingAddressIds.containsAll(['a', 'b']))
+    ).toBe('shippingAddressIds contains all ("a", "b")')
+    expect(
+      build<Customer>((c) => c.shippingAddressIds.containsAny(['a', 'b']))
+    ).toBe('shippingAddressIds contains any ("a", "b")')
+  })
+
+  it('builds emptiness and definedness', () => {
+    expect(build<Customer>((c) => c.addresses.isEmpty())).toBe(
+      'addresses is empty'
+    )
+    expect(build<Customer>((c) => c.addresses.isNotEmpty())).toBe(
+      'addresses is not empty'
+    )
+    expect(build<Customer>((c) => c.key.isDefined())).toBe('key is defined')
+    expect(build<Customer>((c) => c.customerGroup.isNotDefined())).toBe(
+      'customerGroup is not defined'
+    )
+  })
+
+  it('renders booleans and numbers unquoted', () => {
+    expect(build<Customer>((c) => c.isEmailVerified.is(true))).toBe(
+      'isEmailVerified = true'
+    )
+    expect(
+      build<Cart>((cart) => cart.totalPrice((p) => p.centAmount.is(1000)))
+    ).toBe('totalPrice(centAmount = 1000)')
+  })
+
+  it('escapes quotes and backslashes in string values', () => {
+    expect(build<Customer>((c) => c.lastName.is('O"Brien'))).toBe(
+      'lastName = "O\\"Brien"'
+    )
+    expect(build<Customer>((c) => c.lastName.is('a\\b'))).toBe(
+      'lastName = "a\\\\b"'
+    )
+  })
+
+  it('combines with and, or and not', () => {
+    expect(
+      build<Customer>((c) => c.firstName.is('Martha').and(c.lastName.is('Doe')))
+    ).toBe('(firstName = "Martha") and (lastName = "Doe")')
+    expect(
+      build<Customer>((c) => c.firstName.is('Martha').or(c.lastName.is('Doe')))
+    ).toBe('(firstName = "Martha") or (lastName = "Doe")')
+    expect(build<Customer>((c) => not(c.isEmailVerified.is(true)))).toBe(
+      'not (isEmailVerified = true)'
+    )
+  })
+
+  it('parenthesises each operand so the grouping is never left to precedence', () => {
+    const predicate = build<Customer>((c) =>
+      c.firstName
+        .is('Martha')
+        .and(c.lastName.is('Doe').or(c.lastName.is('Jones')))
+    )
+
+    expect(predicate).toBe(
+      '(firstName = "Martha") and ((lastName = "Doe") or (lastName = "Jones"))'
+    )
+  })
+
+  it('accepts several operands in one and', () => {
+    expect(
+      build<Customer>((c) =>
+        c.firstName.is('a').and(c.lastName.is('b'), c.key.is('c'))
+      )
+    ).toBe('(firstName = "a") and (lastName = "b") and (key = "c")')
+  })
+
+  it('reads the predicate string back off a built predicate', () => {
+    const resource = createPredicateRoot() as ResourcePredicate<Customer>
+    const predicate = resource.firstName
+      .is('Martha')
+      .and(resource.lastName.is('Doe'))
+
+    expect(String(predicate)).toBe(
+      '(firstName = "Martha") and (lastName = "Doe")'
+    )
+    expect(`${resource.version.isGreaterThan(10)}`).toBe('version > 10')
+  })
+
+  it('descends into an array of objects', () => {
+    expect(
+      build<Customer>((c) => c.addresses((a) => a.city.is('Berlin')))
+    ).toBe('addresses(city = "Berlin")')
+  })
+
+  it('descends into a nested object', () => {
+    expect(
+      build<Cart>((cart) =>
+        cart.totalPrice((p) => p.centAmount.isGreaterThan(1000))
+      )
+    ).toBe('totalPrice(centAmount > 1000)')
+  })
+
+  it('nests to any depth', () => {
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) => current.slug.locale('en').is('super-product'))
+        )
+      )
+    ).toBe('masterData(current(slug(en = "super-product")))')
+  })
+
+  it('addresses a locale of a localized field', () => {
+    expect(build<Category>((c) => c.name.locale('en').is('Peter'))).toBe(
+      'name(en = "Peter")'
+    )
+    expect(build<Category>((c) => c.name.locale('en-GB').isNot('Peter'))).toBe(
+      'name(en-GB != "Peter")'
+    )
+  })
+
+  it('exposes a reference by id', () => {
+    expect(
+      build<Customer>((c) => c.customerGroup((g) => g.id.is('group-id')))
+    ).toBe('customerGroup(id = "group-id")')
+  })
+
+  it('exposes a key reference by key', () => {
+    expect(build<Customer>((c) => c.stores((s) => s.key.is('berlin')))).toBe(
+      'stores(key = "berlin")'
+    )
+  })
+
+  it('addresses a custom field by name', () => {
+    expect(
+      build<Customer>((c) => c.custom((x) => x.field('size').is('M')))
+    ).toBe('custom(fields(size = "M"))')
+    expect(
+      build<Customer>((c) =>
+        c.custom((x) => x.field('rating').isGreaterThan(3))
+      )
+    ).toBe('custom(fields(rating > 3))')
+  })
+
+  it('addresses the type of a custom field container', () => {
+    expect(
+      build<Customer>((c) => c.custom((x) => x.type((t) => t.id.is('type-id'))))
+    ).toBe('custom(type(id = "type-id"))')
+  })
+
+  it('uses the predicate name where the schema renames a field', () => {
+    // `attributesRaw` in the schema is `attributes` in a predicate.
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) =>
+            current.variants((v) =>
+              v.attributes((a) => a.name.is('color').and(a.value.is('red')))
+            )
+          )
+        )
+      )
+    ).toBe(
+      'masterData(current(variants(attributes((name = "color") and (value = "red")))))'
+    )
+  })
+
+  it('addresses a locale of an attribute value', () => {
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) =>
+            current.variants((v) =>
+              v.attributes((a) =>
+                a.name.is('color').and(a.value.locale('en-US').is('red'))
+              )
+            )
+          )
+        )
+      )
+    ).toBe(
+      'masterData(current(variants(attributes((name = "color") and (value(en-US = "red"))))))'
+    )
+  })
+
+  it('rejects a callback that does not return a predicate', () => {
+    expect(() => build<Customer>(() => undefined as any)).toThrow(
+      /must return a predicate/
+    )
+    expect(() => build<Customer>((c) => c.firstName as any)).toThrow(
+      /must return a predicate/
+    )
+  })
+
+  it('rejects a nested callback that does not return a predicate', () => {
+    expect(() =>
+      build<Customer>((c) => c.addresses(() => 'nope' as any))
+    ).toThrow(/must return a predicate/)
+  })
+
+  it('does not expose symbol properties as predicate members', () => {
+    const resource = createPredicateRoot()
+
+    expect(resource[Symbol.toPrimitive]).toBeUndefined()
+    expect(resource[Symbol.iterator]).toBeUndefined()
+  })
+})
+
+/**
+ * Predicates the API would reject, which the builder refuses to compile instead. Every
+ * `@ts-expect-error` below *is* the assertion: `yarn typecheck` fails with an unused directive
+ * if the line it annotates turns out to be valid. Nothing in here is meant to run.
+ */
+function predicatesThatMustNotCompile() {
+  // @ts-expect-error `firstNam` is a typo.
+  build<Customer>((c) => c.firstNam.is('Martha'))
+
+  // @ts-expect-error `firstName` holds a string, not a number.
+  build<Customer>((c) => c.firstName.is(42))
+
+  // A Reference exposes only `id` and `typeId` inside a predicate, never the fields of the
+  // resource it points at.
+  // @ts-expect-error `name` is a field of the CustomerGroup, not of the reference.
+  build<Customer>((c) => c.customerGroup((g) => g.name.is('wholesale')))
+
+  // @ts-expect-error a boolean is compared for equality only.
+  build<Customer>((c) => c.isEmailVerified.isGreaterThan(true))
+
+  // @ts-expect-error `firstName` holds one value, not a collection.
+  build<Customer>((c) => c.firstName.containsAny(['a']))
+
+  // @ts-expect-error `nameAllLocales` is a projection helper, not a predicate field.
+  build<Category>((c) => c.nameAllLocales.is('Peter'))
+
+  // @ts-expect-error the predicate addresses `customerGroup`, not `customerGroupRef`.
+  build<Customer>((c) => c.customerGroupRef((g) => g.id.is('group-id')))
+
+  build<Product>((p) =>
+    p.masterData((d) =>
+      d.current((current) =>
+        // @ts-expect-error the predicate name is `attributes`, not `attributesRaw`.
+        current.variants((v) => v.attributesRaw((a) => a.name.is('color')))
+      )
+    )
+  )
+}
+
+describe('what the predicate builder refuses to compile', () => {
+  it('rejects predicates the API would reject', () => {
+    // The assertions are the `@ts-expect-error` directives above, checked by `yarn typecheck`.
+    // This keeps the function referenced so it is not reported as dead code.
+    expect(typeof predicatesThatMustNotCompile).toBe('function')
+  })
+})
+
+describe('where on the chain', () => {
+  it('sends a built predicate as a variable, the same as a string', async () => {
+    const { apiRoot, executeRequest } = createApiRoot()
+
+    await createGraphQLClient(apiRoot)
+      .query({
+        customers: (customers) =>
+          customers
+            .where((customer) =>
+              customer.firstName
+                .is('Martha')
+                .and(customer.addresses((address) => address.city.is('Berlin')))
+            )
+            .limit(20)
+            .total(),
+      })
+      .execute()
+
+    const request = executeRequest.mock.calls[0][0]
+
+    expect(request.body.variables).toEqual({
+      v1: '(firstName = "Martha") and (addresses(city = "Berlin"))',
+      v2: 20,
+    })
+    expect(request.body.query.replace(/\s+/g, ' ')).toContain(
+      'customers(where:$v1,limit:$v2)'
+    )
+  })
+
+  it('keeps taking a predicate string', async () => {
+    const { apiRoot, executeRequest } = createApiRoot()
+
+    await createGraphQLClient(apiRoot)
+      .query({
+        customers: (customers) => customers.where('firstName="Martha"').total(),
+      })
+      .execute()
+
+    expect(executeRequest.mock.calls[0][0].body.variables).toEqual({
+      v1: 'firstName="Martha"',
+    })
+  })
+
+  it('builds the predicate of a nested query field', async () => {
+    const { apiRoot, executeRequest } = createApiRoot()
+
+    await createGraphQLClient(apiRoot)
+      .query({
+        inStore: (inStore) =>
+          inStore
+            .key('berlin')
+            .customers((customers) =>
+              customers
+                .where((customer) => customer.email.is('m@example.com'))
+                .total()
+            ),
+      })
+      .execute()
+
+    expect(executeRequest.mock.calls[0][0].body.variables).toEqual({
+      v1: 'berlin',
+      v2: 'email = "m@example.com"',
+    })
+  })
+
+  it('leaves a selection callback on an object field alone', async () => {
+    const { apiRoot, executeRequest } = createApiRoot()
+
+    // `results` takes a projection callback, `where` a predicate callback. Both are functions,
+    // so this is the case that tells them apart.
+    await createGraphQLClient(apiRoot)
+      .query({
+        customers: (customers) =>
+          customers
+            .where((customer) => customer.firstName.is('Martha'))
+            .results((result) => result.firstName()),
+      })
+      .execute()
+
+    const query = executeRequest.mock.calls[0][0].body.query.replace(
+      /\s+/g,
+      ' '
+    )
+
+    expect(query).toContain('customers(where:$v1)')
+    expect(query).toContain('results{firstName}')
+    expect(executeRequest.mock.calls[0][0].body.variables).toEqual({
+      v1: 'firstName = "Martha"',
+    })
+  })
+
+  it('types the response the same way as a string predicate', async () => {
+    const { apiRoot } = createApiRoot({
+      data: { customers: { total: 1, results: [{ email: 'm@example.com' }] } },
+    })
+
+    const data = await createGraphQLClient(apiRoot)
+      .query({
+        customers: (customers) =>
+          customers
+            .where((customer) => customer.firstName.is('Martha'))
+            .total()
+            .results((result) => result.email()),
+      })
+      .executeOrThrow()
+
+    const total: number = data.customers.total
+    const email: string = data.customers.results[0].email
+
+    expect(total).toBe(1)
+    expect(email).toBe('m@example.com')
+  })
+
+  it('checks the resource a nested where filters over', async () => {
+    const { apiRoot } = createApiRoot()
+
+    createGraphQLClient(apiRoot).query({
+      customers: (customers) =>
+        customers
+          // @ts-expect-error `orderState` belongs to an Order, not to a Customer.
+          .where((customer) => customer.orderState.is('Confirmed'))
+          .total(),
+    })
+  })
+})

--- a/packages/graphql-sdk/tests/where.test.ts
+++ b/packages/graphql-sdk/tests/where.test.ts
@@ -4,6 +4,7 @@ import type { Predicate, ResourcePredicate } from '../src'
 import type {
   Cart,
   Category,
+  Channel,
   Customer,
   Product,
 } from '../src/builder/generated'
@@ -249,6 +250,124 @@ describe('the predicate builder', () => {
     )
   })
 
+  it('descends into an attribute value that holds an object', () => {
+    // A Money attribute: `value(centAmount = 999 and currencyCode = "EUR")`.
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) =>
+            current.variants((v) =>
+              v.attributes((a) =>
+                a.name
+                  .is('price')
+                  .and(
+                    a.value((value) =>
+                      value.centAmount
+                        .isGreaterThan(999)
+                        .and(value.currencyCode.is('EUR'))
+                    )
+                  )
+              )
+            )
+          )
+        )
+      )
+    ).toBe(
+      'masterData(current(variants(attributes((name = "price") and (value((centAmount > 999) and (currencyCode = "EUR")))))))'
+    )
+  })
+
+  it('descends into an enum and a reference attribute value', () => {
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) =>
+            current.masterVariant((v) =>
+              v.attributes((a) =>
+                a.name.is('size').and(a.value((value) => value.key.is('m')))
+              )
+            )
+          )
+        )
+      )
+    ).toBe(
+      'masterData(current(masterVariant(attributes((name = "size") and (value(key = "m"))))))'
+    )
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) =>
+            current.masterVariant((v) =>
+              v.attributes((a) =>
+                a.name
+                  .is('manufacturer')
+                  .and(
+                    a.value((value) =>
+                      value.typeId.is('product').and(value.id.is('product-id'))
+                    )
+                  )
+              )
+            )
+          )
+        )
+      )
+    ).toBe(
+      'masterData(current(masterVariant(attributes((name = "manufacturer") and (value((typeId = "product") and (id = "product-id")))))))'
+    )
+  })
+
+  it('descends into a custom field that holds an object', () => {
+    expect(
+      build<Customer>((c) =>
+        c.custom((x) => x.field('budget')((v) => v.centAmount.isLessThan(1000)))
+      )
+    ).toBe('custom(fields(budget(centAmount < 1000)))')
+  })
+
+  it('nests inside an attribute value to any depth', () => {
+    expect(
+      build<Product>((p) =>
+        p.masterData((d) =>
+          d.current((current) =>
+            current.variants((v) =>
+              v.attributes((a) =>
+                a.name
+                  .is('warranty')
+                  .and(a.value((value) => value.duration((x) => x.years.is(2))))
+              )
+            )
+          )
+        )
+      )
+    ).toBe(
+      'masterData(current(variants(attributes((name = "warranty") and (value(duration(years = 2)))))))'
+    )
+  })
+
+  it('matches a geolocation within a circle', () => {
+    expect(
+      build<Channel>((c) => c.geoLocation.withinCircle(13.3777, 52.51627, 1000))
+    ).toBe('geoLocation within circle(13.3777, 52.51627, 1000)')
+  })
+
+  it('combines a geolocation with another condition', () => {
+    expect(
+      build<Channel>((c) =>
+        c.key
+          .is('berlin-warehouse')
+          .and(c.geoLocation.withinCircle(13.3777, 52.51627, 1000))
+      )
+    ).toBe(
+      '(key = "berlin-warehouse") and (geoLocation within circle(13.3777, 52.51627, 1000))'
+    )
+  })
+
+  it('checks whether a geolocation is set at all', () => {
+    expect(build<Channel>((c) => c.geoLocation.isDefined())).toBe(
+      'geoLocation is defined'
+    )
+  })
+
   it('rejects a callback that does not return a predicate', () => {
     expect(() => build<Customer>(() => undefined as any)).toThrow(
       /must return a predicate/
@@ -309,6 +428,14 @@ function predicatesThatMustNotCompile() {
       )
     )
   )
+
+  // A GeoJSON field is compared against a circle, never descended into or compared with a
+  // literal, however the schema types it.
+  // @ts-expect-error `type` is a field of the Point, not of the predicate.
+  build<Channel>((c) => c.geoLocation((g) => g.type.is('Point')))
+
+  // @ts-expect-error a geolocation has no equality operator.
+  build<Channel>((c) => c.geoLocation.is('Point'))
 }
 
 describe('what the predicate builder refuses to compile', () => {


### PR DESCRIPTION
## Summary

`where` on a paged query field keeps taking a [Query Predicate](https://docs.commercetools.com/api/predicates/query) string exactly as before — that stays the escape hatch for anything the builder does not express — and now also takes a callback that builds one through a checked builder:

```ts
const data = await graphQL
  .query({
    customers: (customers) =>
      customers
        .where((customer) =>
          customer.firstName
            .is('Martha')
            .and(customer.addresses((address) => address.city.is('Berlin')))
            .and(customer.customerGroup((group) => group.id.is(goldGroupId)))
        )
        .sort(['lastName asc'])
        .limit(20)
        .results((result) => result.firstName().lastName().email()),
  })
  .executeOrThrow()
```

which sends

```
(firstName = "Martha") and (addresses(city = "Berlin")) and (customerGroup(id = "..."))
```

Field names come from the resource being filtered, and the operators from what the field holds, so a predicate the API would reject is a compile error. That includes the two that are easy to get wrong: a Reference exposes only `id`/`typeId` inside a predicate, never the fields of the resource it points at, and a localized field is addressed per locale.

The builder is derived from the response types genql already generates, so there is no second artefact to keep in step with the schema.

## Changes

- `src/builder/where.ts` (new) — the predicate types and the runtime proxy that emits the string.
- `src/builder/chain.ts` — threads a `TResult` type parameter through the chain so `where` knows which resource it filters over, and resolves a `where` callback at runtime. Defaults to `unknown`, so every other member behaves exactly as before.
- `src/client/graphql-client.ts` — pairs the root selection type with `Query`/`Mutation` so that `TResult` has something to start from.
- `src/index.ts` — exports `not` and the predicate types.
- README section and a changeset.
- Drops the comparisons with the Java and .NET SDKs from the README and the doc comments, so the documentation stands on its own.

## Known limits

Both are documented in the README:

- A handful of schema fields have no counterpart in the response representation a predicate is evaluated against, and are offered even though the API will reject them.
- Query endpoints restrict predicates to a documented subset of fields, which is not machine readable, so the builder does not enforce it.

## Testing

- `packages/graphql-sdk/tests/where.test.ts` (new) covering the emitted strings for each operator, nesting, references, localized fields, Custom Fields, escaping and grouping.
- `yarn jest packages/graphql-sdk` — 88 passed, 5 suites.
- `yarn typecheck` — clean.

## Ticket
[DEVX-856](https://commercetools.atlassian.net/browse/DEVX-856)

[DEVX-856]: https://commercetools.atlassian.net/browse/DEVX-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ