### PR TITLE
[Fix][DEVX-876] Preserve Response Body on Parse

### DIFF
--- a/.changeset/brave-hounds-parse.md
+++ b/.changeset/brave-hounds-parse.md
@@ -1,0 +1,43 @@
+---
+'@commercetools/ts-client': patch
+---
+
+Keep the HTTP status code of an error response whose body is not JSON.
+
+When `fetch` is the `httpClient`, the response body was parsed with `JSON.parse` unconditionally.
+An error response carrying a non-JSON body — typically an HTML page produced by infrastructure in
+front of the API, such as a load balancer returning `502 Bad Gateway` — made that parse throw, and
+the failure surfaced as a generic `NetworkError` with `statusCode: 0`. The real status code was
+lost, so callers could neither classify nor count these responses:
+
+```
+NetworkError: Unexpected token '<', "\n<html><hea"... is not valid JSON
+  statusCode: 0
+```
+
+The parse failure is now caught for responses whose status is an error, and the unparsed body is
+kept. The same response gives:
+
+```
+HttpError: Unexpected non-JSON error response
+  statusCode: 502
+  body: '\n<html><head><title>502 Bad Gateway</title></head>...'
+```
+
+This is what `axios` already returned for the same response, so both HTTP clients now agree.
+
+A response whose status is not an error is still expected to carry a JSON body, and a parse failure
+there keeps surfacing as before, rather than passing an unparsed body to the caller as if the
+request had succeeded.
+
+These infrastructure errors are transient, so also consider adding their status codes to
+`retryConfig.retryCodes`, which is applied to the status before the body is read:
+
+```ts
+createHttpMiddleware({
+  host,
+  httpClient: fetch,
+  enableRetry: true,
+  retryConfig: { retryCodes: [502] },
+})
+```

--- a/packages/sdk-client-v3/src/utils/executor.ts
+++ b/packages/sdk-client-v3/src/utils/executor.ts
@@ -157,18 +157,27 @@ export default async function executor(request: HttpClientConfig) {
         }
       }
 
-      try {
-        // try to parse the `fetch` response as text
-        if (response.text && typeof response.text == 'function') {
-          result = await response.text()
+      // try to parse the `fetch` response as text
+      if (response.text && typeof response.text == 'function') {
+        result = await response.text()
 
+        try {
           data = JSON.parse(result)
-        } else {
-          // axios response
-          data = response.data || response
+        } catch (err) {
+          const statusCode = response.status || response.statusCode
+
+          // An error response can come from infrastructure sitting in front of
+          // the API (e.g. an HTML page from a load balancer). Keep the raw body
+          // so the status code survives, instead of collapsing into a `NetworkError`
+          // with `statusCode: 0`. Anything else, including a response whose status
+          // we do not know, keeps surfacing the parse failure.
+          if (!(statusCode > 399)) throw err
+
+          data = result
         }
-      } catch (err) {
-        throw err
+      } else {
+        // axios response
+        data = response.data || response
       }
 
       return {

--- a/packages/sdk-client-v3/tests/http.test/http-middleware.test.ts
+++ b/packages/sdk-client-v3/tests/http.test/http-middleware.test.ts
@@ -951,4 +951,142 @@ describe('Http Middleware.', () => {
       expect(response).toBeDefined()
     })
   })
+
+  describe('Non-JSON error responses.', () => {
+    const htmlErrorPage =
+      '\n<html><head><title>502 Bad Gateway</title></head>\n<body><h1>502 Bad Gateway</h1></body></html>\n'
+
+    test('should preserve the status code of an error response with a non-JSON body', async () => {
+      const response = createTestResponse({
+        status: 502,
+        text: () => Promise.resolve(htmlErrorPage),
+      })
+
+      const request = createTestRequest({
+        uri: '/standalone-prices',
+        method: 'GET',
+      })
+
+      const httpMiddlewareOptions: HttpMiddlewareOptions = {
+        host: 'http://api-host.com',
+        httpClient: jest.fn(() => response),
+      }
+
+      const next = (req: MiddlewareRequest) => {
+        expect(req.response?.error?.name).toEqual('HttpError')
+        expect(req.response?.error?.statusCode).toEqual(502)
+        expect(req.response?.error?.status).toEqual(502)
+        expect(req.response?.error?.message).toEqual(
+          'Unexpected non-JSON error response'
+        )
+        // the unparsed body is kept so the caller can inspect what arrived
+        expect(req.response?.error?.body).toEqual(htmlErrorPage)
+
+        return response
+      }
+
+      await createHttpMiddleware(httpMiddlewareOptions)(next)(request)
+    })
+
+    test('should retry an error response with a non-JSON body when its status is in `retryCodes`', async () => {
+      const httpClient = jest.fn(() =>
+        createTestResponse({
+          status: 502,
+          text: () => Promise.resolve(htmlErrorPage),
+        })
+      )
+
+      const request = createTestRequest({
+        uri: '/standalone-prices',
+        method: 'GET',
+      })
+
+      const httpMiddlewareOptions: HttpMiddlewareOptions = {
+        host: 'http://api-host.com',
+        httpClient,
+        enableRetry: true,
+        retryConfig: {
+          maxRetries: 3,
+          backoff: false,
+          retryDelay: 1,
+          retryCodes: [502],
+        },
+      }
+
+      const next = (req: MiddlewareRequest): any => {
+        expect(req.response?.error?.statusCode).toEqual(502)
+        expect(req.response?.error?.retryCount).toEqual(3)
+
+        return req.response
+      }
+
+      await createHttpMiddleware(httpMiddlewareOptions)(next)(request)
+
+      // the first attempt plus three retries
+      expect(httpClient).toHaveBeenCalledTimes(4)
+    })
+
+    test('should still surface the parse failure when the response status is not an error', async () => {
+      const response = createTestResponse({
+        text: () => Promise.resolve('<html>not json</html>'),
+      })
+
+      const request = createTestRequest({
+        uri: '/standalone-prices',
+        method: 'GET',
+      })
+
+      const httpMiddlewareOptions: HttpMiddlewareOptions = {
+        host: 'http://api-host.com',
+        httpClient: jest.fn(() => response),
+      }
+
+      const next = (req: MiddlewareRequest) => response
+
+      await expect(
+        createHttpMiddleware(httpMiddlewareOptions)(next)(request)
+      ).rejects.toMatchObject({
+        body: null,
+        error: {
+          name: 'NetworkError',
+          code: 'NetworkError',
+          statusCode: 0,
+        },
+      })
+    })
+
+    test('should not change the handling of an error response with a JSON body', async () => {
+      const _response = {
+        statusCode: 400,
+        message: 'Missing required field.',
+        errors: [{ code: 'RequiredField' }],
+      }
+
+      const response = createTestResponse({
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify(_response)),
+      })
+
+      const request = createTestRequest({
+        uri: '/standalone-prices',
+        method: 'GET',
+      })
+
+      const httpMiddlewareOptions: HttpMiddlewareOptions = {
+        host: 'http://api-host.com',
+        httpClient: jest.fn(() => response),
+      }
+
+      const next = (req: MiddlewareRequest) => {
+        expect(req.response?.error?.name).toEqual('BadRequest')
+        expect(req.response?.error?.code).toEqual('RequiredField')
+        expect(req.response?.error?.statusCode).toEqual(400)
+        expect(req.response?.error?.message).toEqual('Missing required field.')
+
+        return response
+      }
+
+      await createHttpMiddleware(httpMiddlewareOptions)(next)(request)
+    })
+  })
 })


### PR DESCRIPTION
### Summary
Preserve response body on parsing error

### Completed Tasks
- [x] preserve response body on parse
- [x] add tests to validate change

### Related Ticket
[DEVX-876](https://commercetools.atlassian.net/browse/DEVX-876)

[DEVX-876]: https://commercetools.atlassian.net/browse/DEVX-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ